### PR TITLE
feat: Improve RunZero Explorer Molecule and Galaxy config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ logs
 changelogs/.plugin-cache.yaml
 *.pyc
 .task/
-*inventory_aws_ec2.yml
+.ansible
+*.tar.gz

--- a/galaxy-deploy.yml
+++ b/galaxy-deploy.yml
@@ -16,7 +16,7 @@
   gather_facts: false
 
   vars:
-    namespace: l50
+    collection_namespace: l50
     collection: bulwark
     # Requires github_tag to be set when calling playbook.
     release_tag: "{{ github_tag.split('/')[-1] }}"
@@ -53,5 +53,5 @@
 
     - name: Publish the collection.
       ansible.builtin.command: >
-        ansible-galaxy collection publish ./{{ namespace }}-{{ collection }}-{{ release_tag }}.tar.gz
+        ansible-galaxy collection publish ./{{ collection_namespace }}-{{ collection }}-{{ release_tag }}.tar.gz
       changed_when: false

--- a/playbooks/runzero_explorer/molecule/default/converge.yml
+++ b/playbooks/runzero_explorer/molecule/default/converge.yml
@@ -2,11 +2,6 @@
 - name: Converge
   hosts: all
   gather_facts: true
-  pre_tasks:
-    - name: Set ansible_user_id based on OS
-      ansible.builtin.set_fact:
-        ansible_user_id: "{{ 'ubuntu' if ansible_distribution == 'Ubuntu' else 'rocky' }}"
-      when: ansible_distribution in ['Ubuntu', 'RedHat', 'Rocky']
 
 - name: Import playbook for testing
   ansible.builtin.import_playbook: ../../runzero_explorer.yml

--- a/playbooks/runzero_explorer/molecule/default/molecule.yml
+++ b/playbooks/runzero_explorer/molecule/default/molecule.yml
@@ -14,16 +14,19 @@ driver:
 
 platforms:
   - name: ubuntu-runzero-explorer
-    image: geerlingguy/docker-ubuntu2204-ansible:latest
-    command: "" # necessary for systemd
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
+    # Setting the command to this is necessary for systemd containers
+    command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
     privileged: true
 
-  - name: redhat-runzero-explorer
-    image: "geerlingguy/docker-rockylinux9-ansible:latest"
-    command: "" # necessary for systemd
+  - name: kali-runzero-explorer
+    image: cisagov/docker-kali-ansible:latest
+    # Setting the command to this is necessary for systemd containers
+    command: ""
+    pre_build_image: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host
@@ -33,6 +36,9 @@ provisioner:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  # Uncomment for verbose output
+  # env:
+  #   ANSIBLE_VERBOSITY: 3
 
 verifier:
   name: ansible

--- a/playbooks/runzero_explorer/runzero_explorer.yml
+++ b/playbooks/runzero_explorer/runzero_explorer.yml
@@ -1,6 +1,9 @@
 ---
 - name: RunZero Explorer
   hosts: all
+  gather_facts: true
   roles:
     - name: Setup and run RunZero Explorer
       role: l50.bulwark.runzero_explorer
+      # For debugging
+      # role: ../../roles/runzero_explorer

--- a/roles/runzero_explorer/molecule/default/converge.yml
+++ b/roles/runzero_explorer/molecule/default/converge.yml
@@ -1,9 +1,8 @@
 ---
 - name: Converge
   hosts: all
+  gather_facts: true
   tasks:
-    - name: Include default variables
-      ansible.builtin.include_vars:
-        file: "../../defaults/main.yml"
-  roles:
-    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+    - name: Include role under test
+      ansible.builtin.include_role:
+        name: l50.bulwark.runzero_explorer

--- a/roles/runzero_explorer/molecule/default/molecule.yml
+++ b/roles/runzero_explorer/molecule/default/molecule.yml
@@ -13,8 +13,8 @@ driver:
   name: docker
 
 platforms:
-  - name: ubuntu-runzero
-    image: "geerlingguy/docker-ubuntu2204-ansible:latest"
+  - name: ubuntu-runzero-explorer
+    image: geerlingguy/docker-ubuntu2404-ansible:latest
     # Setting the command to this is necessary for systemd containers
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: kali-runzero
+  - name: kali-runzero-explorer
     image: cisagov/docker-kali-ansible:latest
     # Setting the command to this is necessary for systemd containers
     command: ""
@@ -32,19 +32,15 @@ platforms:
     cgroupns_mode: host
     privileged: true
 
-  - name: redhat-runzero
-    image: "geerlingguy/docker-rockylinux9-ansible:latest"
-    # Setting the command to this is necessary for systemd containers
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-
 provisioner:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  env:
+    ANSIBLE_CALLBACK_PLUGINS: "${MOLECULE_SCENARIO_DIRECTORY}/callback_plugins"
+  # Uncomment for verbose output
+  # env:
+  #   ANSIBLE_VERBOSITY: 3
 
 verifier:
   name: ansible


### PR DESCRIPTION
**Key Changes:**

* Refactored `runzero_explorer` Molecule scenario for modern OS support.
* Simplified `converge.yml` using `include_role` with `gather_facts`.
* Improved `.gitignore` for Ansible and archive build artifacts.
* Fixed `galaxy-deploy.yml` to use `collection_namespace` variable.

**Added:**

* `.ansible` and `*.tar.gz` entries to `.gitignore`.
* `gather_facts: true` in Molecule converge playbook.
* Kali Linux platform using `cisagov/docker-kali-ansible` image.
* Optional verbose mode via `ANSIBLE_VERBOSITY` env for Molecule runs.

**Changed:**

* Switched Ubuntu platform to `docker-ubuntu2404-ansible`.
* Replaced Rocky Linux platform with Kali to broaden OS testing.
* Simplified `converge.yml` with `include_role` and removed `include_vars`.
* Updated Galaxy deploy to use `collection_namespace` consistently.

**Removed:**

* Deprecated Rocky Linux platform from Molecule.
* Legacy `pre_tasks` and logic for `ansible_user_id` from converge playbook.
* Static role path logic in favor of collection-style role naming.