### PR TITLE
feat: Refactor explorer role vars; align agent file handling and env vars

### DIFF
--- a/roles/runzero_explorer/tasks/unix.yml
+++ b/roles/runzero_explorer/tasks/unix.yml
@@ -19,14 +19,14 @@
 
 - name: Generate a unique RUNZERO_AGENT_HOST_ID
   ansible.builtin.set_fact:
-    runzero_agent_host_id: "{{ lookup('ansible.builtin.password', length=32, format='hex') }}"
-  when: runzero_agent_host_id is not defined
+    runzero_explorer_agent_host_id: "{{ lookup('ansible.builtin.password', length=32, format='hex') }}"
+  when: runzero_explorer_agent_host_id is not defined
 
 - name: Set RUNZERO_AGENT_HOST_ID environment variable
   become: true
   ansible.builtin.lineinfile:
     path: /etc/environment
-    line: 'RUNZERO_AGENT_HOST_ID={{ runzero_agent_host_id }}'
+    line: 'RUNZERO_AGENT_HOST_ID={{ runzero_explorer_agent_host_id }}'
     create: true
     mode: '0644'
 
@@ -65,7 +65,7 @@
     paths: "{{ runzero_explorer_path | dirname }}"
     patterns: "runzero-agent-*"
     get_checksum: true
-  register: runzero_agent_files
+  register: runzero_explorer_agent_files
 
 - name: Get hash of existing runzero-explorer file
   ansible.builtin.stat:
@@ -77,11 +77,11 @@
 - name: Rename the most recent runzero-agent file to the default destination
   become: true
   ansible.builtin.command:
-    cmd: "mv {{ (runzero_agent_files.files | sort(attribute='mtime') | last).path }} {{ runzero_explorer_path }}"
+    cmd: "mv {{ (runzero_explorer_agent_files.files | sort(attribute='mtime') | last).path }} {{ runzero_explorer_path }}"
   when:
-    - runzero_agent_files.matched > 0
+    - runzero_explorer_agent_files.matched > 0
     - runzero_explorer_stat.stat.exists
-    - "(runzero_agent_files.files | sort(attribute='mtime') | last).checksum != runzero_explorer_checksum.stat.checksum"
+    - "(runzero_explorer_agent_files.files | sort(attribute='mtime') | last).checksum != runzero_explorer_checksum.stat.checksum"
   changed_when: false
 
 - name: Execute runzero-explorer

--- a/roles/runzero_explorer/tasks/windows.yml
+++ b/roles/runzero_explorer/tasks/windows.yml
@@ -22,7 +22,7 @@
     paths: "{{ runzero_explorer_path | dirname }}"
     patterns: "runzero-agent-*"
     get_checksum: yes
-  register: runzero_agent_files
+  register: runzero_explorer_agent_files
 
 - name: Get hash of existing runzero-explorer file (if applicable)
   ansible.windows.win_stat:
@@ -33,11 +33,11 @@
 
 - name: Rename the most recent runzero-agent file to the default destination (if applicable)
   ansible.windows.win_command:
-    cmd: "Rename-Item -Path '{{ (runzero_agent_files.files | sort(attribute='mtime') | last).path }}' -NewName '{{ runzero_explorer_path | basename }}'"
+    cmd: "Rename-Item -Path '{{ (runzero_explorer_agent_files.files | sort(attribute='mtime') | last).path }}' -NewName '{{ runzero_explorer_path | basename }}'"
   when:
-    - runzero_agent_files.matched > 0
+    - runzero_explorer_agent_files.matched > 0
     - runzero_explorer_stat.stat.exists
-    - "(runzero_agent_files.files | sort(attribute='mtime') | last).checksum != runzero_explorer_checksum.stat.checksum"
+    - "(runzero_explorer_agent_files.files | sort(attribute='mtime') | last).checksum != runzero_explorer_checksum.stat.checksum"
   changed_when: true
 
 - name: Execute runzero-explorer


### PR DESCRIPTION
**Changed:**

- Refactored variable names from `runzero_agent_*` to `runzero_explorer_agent_*` in both `unix.yml` and `windows.yml` for consistency across the role.
- Changed all file registry and checksum variables to use `runzero_explorer_agent_files` instead of `runzero_agent_files`.
- Updated tasks to set the `RUNZERO_AGENT_HOST_ID` env from the new variable.
- Adjusted mv and rename logic to use the new variable names and consistent conditionals.