### PR TITLE
ci: update renovate automerge rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,6 +41,19 @@
       "automerge": true,
       "automergeType": "pr",
       "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ]
+    },
+    {
+      "description": "Auto-merge custom regex managers (task, python, go versions)",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": [
         "minor",
         "patch"
       ]


### PR DESCRIPTION
**Key Changes:**

- Expanded Renovate automerge coverage for existing matched dependencies to include major updates
- Added automerge handling for custom regex-managed versions, including task, Python, and Go updates
- Scoped custom regex automerge to minor and patch updates to avoid automatically merging major toolchain changes

**Added:**

- Custom regex manager automerge rule - Configures Renovate to open automerge PRs for minor and patch updates detected by custom regex managers

**Changed:**

- Existing dependency automerge policy - Allows major, minor, and patch updates for the pre-existing matched dependency rule instead of limiting automation to lower-risk update types