### PR TITLE
fix: add roles table markers to README so pre-commit hook passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ ansible-galaxy collection build --force && \
 
 ## Roles
 
+<!-- ROLES TABLE START -->
+
+| Role | Description |
+| ---- | ----------- |
+| [`runzero_explorer`](roles/runzero_explorer/README.md) | Install the runZero explorer |
+
+<!-- ROLES TABLE END -->
+
 ### runZero Explorer
 
 Installs and configures [runZero Explorer](https://console.runzero.com/deploy/download/explorers).


### PR DESCRIPTION
**Key Changes:**

- Restored a green pre-commit run on every PR by giving the `update-architecture-diagram` hook the README.md markers it expects since #494
- Auto-populated the roles table block under the existing `## Roles` section, leaving the hand-written `### runZero Explorer` notes intact
- Unblocks #496 (and any other PR opened against `main`) without touching the hook script

**Added:**

- Roles table markers in `README.md` - Inserted `<!-- ROLES TABLE START -->` and `<!-- ROLES TABLE END -->` under `## Roles` and let `.hooks/gen-arch-diagram.py` fill in the generated `runzero_explorer` row between them