### PR TITLE
ci: add repository_dispatch trigger and refine template sync scope

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -13,19 +13,14 @@ on:
         default: "debug"
         required: false
 
-  schedule:
-    # Run on the 1st of every month at 00:00 UTC
-    - cron: "0 0 1 * *"
+  # Fan-out from CowDogMoo/ansible-collection-workstation's Template Sync
+  # Dispatch workflow; fires within minutes of a template change there.
+  repository_dispatch:
+    types: [template-sync]
 
-  push:
-    branches: ["main"]
-    paths:
-      - '.github/**'
-      - '.hooks/**'
-      - '.pre-commit-config.yaml'
-      - '.mdlrc'
-      - '.editorconfig'
-      - 'Taskfile.yaml'
+  schedule:
+    # Monthly safety net in case a dispatch event is missed.
+    - cron: "0 0 1 * *"
 
 concurrency:
   cancel-in-progress: true
@@ -64,12 +59,12 @@ jobs:
           pr_body: |
             🤖 A new version of the ansible collection template files is available.
 
-            This PR was automatically created to sync the following:
-            - GitHub Actions workflows
-            - Pre-commit hooks and configurations
-            - Ansible-lint configurations
-            - Task definitions
-            - Editor configs and linter rules
+            This PR was automatically created to sync shared infrastructure:
+            - Pre-commit hooks (`.hooks/**`, `.pre-commit-config.yaml`)
+            - Task definitions (`Taskfile.yaml`)
+            - Editor configs (`.editorconfig`)
+
+            Workflow files are managed by Renovate and excluded from this sync.
 
             Please review the changes carefully before merging.
           source_repo_path: CowDogMoo/ansible-collection-workstation

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -14,7 +14,5 @@ requirements.yml
 .github/renovate.json5
 .github/labeler.yaml
 .github/labels.yaml
-# All workflow files are ceded to Renovate; template-sync no longer touches them.
 .github/workflows/*
-# Generated per-collection diagram — never propagate workstation's copy.
 arch-diagram/collection_mermaid.md

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -14,6 +14,5 @@ requirements.yml
 .github/renovate.json5
 .github/labeler.yaml
 .github/labels.yaml
-.github/workflows/release.yaml
-.github/workflows/molecule.yaml
-arch-diagram/collection_mermaid.md
+# All workflow files are ceded to Renovate; template-sync no longer touches them.
+.github/workflows/*

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -16,3 +16,5 @@ requirements.yml
 .github/labels.yaml
 # All workflow files are ceded to Renovate; template-sync no longer touches them.
 .github/workflows/*
+# Generated per-collection diagram — never propagate workstation's copy.
+arch-diagram/collection_mermaid.md


### PR DESCRIPTION
**Key Changes:**

- Replaced push-based trigger with `repository_dispatch` event for near-real-time sync when upstream template changes
- Broadened `.templatesyncignore` to exclude all workflow files, delegating workflow management to Renovate
- Updated PR body messaging to reflect the narrower sync scope and clarify what is and isn't managed by this workflow

**Changed:**

- Template sync triggers - Removed the `push` trigger (which fired on changes to `.github/**`, `.hooks/**`, and related files) and added a `repository_dispatch` event of type `template-sync` so syncs fire within minutes of an upstream template change; the monthly `schedule` cron is retained as a safety net in case a dispatch event is missed
- Workflow file exclusion scope - Replaced individual workflow exclusions (`release.yaml`, `molecule.yaml`) with a wildcard `.github/workflows/*` in `.templatesyncignore`, ensuring all workflow files are excluded from template sync and managed solely by Renovate
- PR body description - Updated auto-generated PR body to accurately list only the files this sync manages (pre-commit hooks, task definitions, editor configs) and explicitly notes that workflow files are handled by Renovate