### PR TITLE
chore: enable major version automerge in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,7 @@
       "automerge": true,
       "automergeType": "pr",
       "matchUpdateTypes": [
+        "major",
         "minor",
         "patch"
       ]


### PR DESCRIPTION
**Key Changes:**

- Extended automerge policy to include major version updates in Renovate configuration
- Previously only minor and patch updates were eligible for automatic merging
- Major version updates will now be automatically merged via PR without manual intervention

**Changed:**

- Renovate automerge policy - Added `"major"` to the `matchUpdateTypes` array in `.github/renovate.json5` so that major version dependency updates are included alongside minor and patch updates for automatic PR merging