### PR TITLE
feat: add resilient download configuration for runzero explorer

### DIFF
--- a/roles/runzero_explorer/README.md
+++ b/roles/runzero_explorer/README.md
@@ -18,6 +18,10 @@ Install the runZero explorer
 | `runzero_explorer_log_debug` | str | <code>false</code> | No description |
 | `runzero_explorer_systemd_enabled` | str | <code>false</code> | No description |
 | `runzero_explorer_version_id` | str | <code>1a430dd4</code> | No description |
+| `runzero_explorer_debug_download` | bool | <code>False</code> | No description |
+| `runzero_explorer_download_retries` | int | <code>5</code> | No description |
+| `runzero_explorer_download_delay` | int | <code>10</code> | No description |
+| `runzero_explorer_download_timeout` | int | <code>60</code> | No description |
 
 ### Role Variables (main.yml)
 

--- a/roles/runzero_explorer/defaults/main.yml
+++ b/roles/runzero_explorer/defaults/main.yml
@@ -2,3 +2,10 @@
 runzero_explorer_log_debug: "false"
 runzero_explorer_systemd_enabled: "false"
 runzero_explorer_version_id: "1a430dd4"
+# Unmask the download task (no_log) to surface errors when troubleshooting.
+# Leave false so the token-bearing URL is never exposed in logs by default.
+runzero_explorer_debug_download: false
+# Resilience settings for the explorer download against transient network failures.
+runzero_explorer_download_retries: 5
+runzero_explorer_download_delay: 10
+runzero_explorer_download_timeout: 60

--- a/roles/runzero_explorer/tasks/unix.yml
+++ b/roles/runzero_explorer/tasks/unix.yml
@@ -58,10 +58,15 @@
     url: "{{ runzero_explorer_url }}"
     dest: "{{ runzero_explorer_path }}"
     mode: '0755'
+    timeout: "{{ runzero_explorer_download_timeout | int }}"
+  register: runzero_explorer_download
+  retries: "{{ runzero_explorer_download_retries | int }}"
+  delay: "{{ runzero_explorer_download_delay | int }}"
+  until: runzero_explorer_download is succeeded
   when:
     - runzero_explorer_unique_token is defined
     - not runzero_explorer_stat.stat.exists
-  no_log: true
+  no_log: "{{ not (runzero_explorer_debug_download | bool) }}"
 
 - name: Find runzero-agent files
   ansible.builtin.find:

--- a/roles/runzero_explorer/tasks/windows.yml
+++ b/roles/runzero_explorer/tasks/windows.yml
@@ -14,10 +14,15 @@
   ansible.windows.win_get_url:
     url: "{{ runzero_explorer_url }}"
     dest: "{{ runzero_explorer_path }}"
+    timeout: "{{ runzero_explorer_download_timeout | int }}"
+  register: runzero_explorer_download
+  retries: "{{ runzero_explorer_download_retries | int }}"
+  delay: "{{ runzero_explorer_download_delay | int }}"
+  until: runzero_explorer_download is succeeded
   when:
     - runzero_explorer_unique_token is defined
     - not runzero_explorer_stat.stat.exists
-  no_log: true
+  no_log: "{{ not (runzero_explorer_debug_download | bool) }}"
 
 - name: Find runzero-agent files (if applicable)
   ansible.windows.win_find:


### PR DESCRIPTION
**Key Changes:**

- Introduced configurable retry, delay, and timeout settings for the explorer download task to handle transient network failures
- Made `no_log` behavior toggleable via a new debug flag, allowing token-bearing URLs to be exposed only when explicitly enabled for troubleshooting
- Applied consistent download resilience settings across both Unix and Windows task files

**Added:**

- Download resilience defaults - Added `runzero_explorer_download_retries` (5), `runzero_explorer_download_delay` (10), and `runzero_explorer_download_timeout` (60) to `defaults/main.yml` with inline comments explaining their purpose
- Debug download flag - Added `runzero_explorer_debug_download` (default: `false`) to safely unmask the download task's `no_log` behavior during troubleshooting without exposing the token-bearing URL in normal operation
- README documentation - Documented all four new variables in the role's variable reference table

**Changed:**

- Unix download task - Updated `ansible.builtin.get_url` in `tasks/unix.yml` to apply `timeout`, `retries`, `delay`, and `until` directives using the new variables, and replaced the hardcoded `no_log: true` with a dynamic expression driven by `runzero_explorer_debug_download`
- Windows download task - Applied the same resilience and conditional `no_log` changes to `ansible.windows.win_get_url` in `tasks/windows.yml` for consistency with the Unix task