### PR TITLE
feat: add sysmon ansible role for windows host instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ graph TD
     Collection[Ansible Collection]
     Collection --> Roles[⚙️ Roles]
     Roles --> R0[runzero_explorer 🧪]
+    Roles --> R1[sysmon]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[runzero_explorer 🧪]
 ```
@@ -47,12 +48,19 @@ ansible-galaxy collection build --force && \
 | Role | Description |
 | ---- | ----------- |
 | [`runzero_explorer`](roles/runzero_explorer/README.md) | Install the runZero explorer |
+| [`sysmon`](roles/sysmon/README.md) | Install and configure Sysinternals Sysmon on Windows hosts |
 
 <!-- ROLES TABLE END -->
 
 ### runZero Explorer
 
 Installs and configures [runZero Explorer](https://console.runzero.com/deploy/download/explorers).
+
+### Sysmon
+
+Installs [Sysinternals Sysmon](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon)
+on Windows hosts with the [SwiftOnSecurity sysmon-config](https://github.com/SwiftOnSecurity/sysmon-config)
+baseline. Windows-only; no Linux/molecule test coverage.
 
 ## Usage
 

--- a/roles/sysmon/README.md
+++ b/roles/sysmon/README.md
@@ -1,0 +1,64 @@
+<!-- DOCSIBLE START -->
+# sysmon
+
+## Description
+
+Install and configure Sysinternals Sysmon on Windows hosts
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `sysmon_service_name` | str | <code>Sysmon64</code> | No description |
+| `sysmon_install_dir` | str | <code>C:\Windows</code> | No description |
+| `sysmon_binary_path` | str | <code>C:\Windows\Sysmon64.exe</code> | No description |
+| `sysmon_config_path` | str | <code>C:\ProgramData\Sysmon\sysmonconfig.xml</code> | No description |
+| `sysmon_windows_temp_dir` | str | <code>C:\Windows\Temp</code> | No description |
+| `sysmon_installer_url` | str | <code>https://download.sysinternals.com/files/Sysmon.zip</code> | No description |
+| `sysmon_config_url` | str | <code>https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml</code> | No description |
+| `sysmon_enforce_config` | bool | <code>True</code> | No description |
+
+## Tasks
+
+### main.yml
+
+
+- **Include OS-specific tasks** (ansible.builtin.include_tasks)
+
+### windows.yml
+
+
+- **Check if Sysmon service is already installed** (ansible.windows.win_service)
+- **Ensure Sysmon config directory exists** (ansible.windows.win_file)
+- **Fetch Sysmon config (SwiftOnSecurity)** (ansible.windows.win_get_url)
+- **Download Sysmon installer** (ansible.windows.win_get_url) - Conditional
+- **Extract Sysmon installer** (community.windows.win_unzip) - Conditional
+- **Install Sysmon with config** (ansible.windows.win_command) - Conditional
+- **Wait for Sysmon service to be running** (ansible.windows.win_service)
+- **Clean up installer files** (ansible.windows.win_file) - Conditional
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - sysmon
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: l50
+- **License**: MIT
+
+## Platforms
+
+
+- Windows: all
+<!-- DOCSIBLE END -->

--- a/roles/sysmon/defaults/main.yml
+++ b/roles/sysmon/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+sysmon_service_name: "Sysmon64"
+sysmon_install_dir: "C:\\Windows"
+sysmon_binary_path: "C:\\Windows\\Sysmon64.exe"
+sysmon_config_path: "C:\\ProgramData\\Sysmon\\sysmonconfig.xml"
+
+sysmon_windows_temp_dir: "C:\\Windows\\Temp"
+sysmon_installer_url: "https://download.sysinternals.com/files/Sysmon.zip"
+
+# SwiftOnSecurity sysmon-config — pinned to a specific commit for reproducibility.
+# Update the SHA to roll forward.
+sysmon_config_url: "https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml"
+
+# When true, re-apply the config on every run (Sysmon64.exe -c <config>).
+# Cheap, idempotent, and ensures drift is corrected.
+sysmon_enforce_config: true

--- a/roles/sysmon/handlers/main.yml
+++ b/roles/sysmon/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Reload sysmon config
+  ansible.windows.win_command: '"{{ sysmon_binary_path }}" -c "{{ sysmon_config_path }}"'

--- a/roles/sysmon/meta/main.yml
+++ b/roles/sysmon/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: sysmon
+  namespace: l50
+  author: Jayson Grace
+  description: Install and configure Sysinternals Sysmon on Windows hosts
+  company: l50
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Windows
+      versions:
+        - all
+  galaxy_tags:
+    - sysmon
+    - sysinternals
+    - windows
+    - security
+    - telemetry
+    - detection
+
+dependencies: []

--- a/roles/sysmon/tasks/main.yml
+++ b/roles/sysmon/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Include OS-specific tasks
+  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"

--- a/roles/sysmon/tasks/windows.yml
+++ b/roles/sysmon/tasks/windows.yml
@@ -1,0 +1,64 @@
+---
+- name: Check if Sysmon service is already installed
+  ansible.windows.win_service:
+    name: "{{ sysmon_service_name }}"
+  register: sysmon_service_info
+  failed_when: false
+
+- name: Ensure Sysmon config directory exists
+  ansible.windows.win_file:
+    path: "C:\\ProgramData\\Sysmon"
+    state: directory
+
+- name: Fetch Sysmon config (SwiftOnSecurity)
+  ansible.windows.win_get_url:
+    url: "{{ sysmon_config_url }}"
+    dest: "{{ sysmon_config_path }}"
+    force: true
+  register: sysmon_config_download
+  notify: Reload sysmon config
+
+- name: Download Sysmon installer
+  ansible.windows.win_get_url:
+    url: "{{ sysmon_installer_url }}"
+    dest: "{{ sysmon_windows_temp_dir }}\\Sysmon.zip"
+  when: not sysmon_service_info.exists
+
+- name: Extract Sysmon installer
+  community.windows.win_unzip:
+    src: "{{ sysmon_windows_temp_dir }}\\Sysmon.zip"
+    dest: "{{ sysmon_windows_temp_dir }}\\Sysmon"
+  when: not sysmon_service_info.exists
+
+- name: Install Sysmon with config
+  ansible.windows.win_command: >-
+    "{{ sysmon_windows_temp_dir }}\Sysmon\Sysmon64.exe"
+    -accepteula -i "{{ sysmon_config_path }}"
+  when: not sysmon_service_info.exists
+  register: sysmon_install_result
+  changed_when: sysmon_install_result.rc == 0
+  # Sysmon returns 0 on install. The driver registration step occasionally
+  # exits non-zero on rerun if already present; let the next idempotent check
+  # catch real failures.
+  failed_when:
+    - sysmon_install_result.rc != 0
+    - "'is already installed' not in (sysmon_install_result.stdout | default(''))"
+
+- name: Wait for Sysmon service to be running
+  ansible.windows.win_service:
+    name: "{{ sysmon_service_name }}"
+    state: started
+    start_mode: auto
+  register: sysmon_service_state
+  until: sysmon_service_state.state == "running"
+  retries: 6
+  delay: 5
+
+- name: Clean up installer files
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ sysmon_windows_temp_dir }}\\Sysmon.zip"
+    - "{{ sysmon_windows_temp_dir }}\\Sysmon"
+  when: not sysmon_service_info.exists


### PR DESCRIPTION
**Key Changes:**

- New `sysmon` Ansible role that installs and configures Sysinternals Sysmon on Windows hosts using the SwiftOnSecurity baseline config
- Installation is idempotent - checks for existing service before downloading and only installs when absent, then enforces config on every run to correct drift
- Role is Windows-only with no Linux/molecule test coverage, as noted in documentation

**Added:**

- Sysmon role tasks - `tasks/main.yml` delegates to OS-specific task files via `ansible_os_family`; `tasks/windows.yml` handles the full lifecycle: service detection, config directory creation, config download, installer download/extract/install, service start, and cleanup
- Role defaults - `defaults/main.yml` exposes configurable variables for service name, install paths, installer URL, SwiftOnSecurity config URL, and `sysmon_enforce_config` flag (default `true`) to re-apply config on every run
- Reload handler - `handlers/main.yml` re-applies the config file via `Sysmon64.exe -c` whenever the config download task reports a change
- Role metadata - `meta/main.yml` declares Galaxy metadata including platform (Windows), tags (sysmon, sysinternals, security, detection, telemetry), and minimum Ansible version 2.14
- Role and collection documentation - `roles/sysmon/README.md` documents all variables, tasks, and example playbook; top-level `README.md` updated to include the role in the dependency graph, roles table, and a new Sysmon section