### PR TITLE
feat: add dc_audit_sacl role for domain controller attack detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ response, and system hardening.
 graph TD
     Collection[Ansible Collection]
     Collection --> Roles[⚙️ Roles]
-    Roles --> R0[runzero_explorer 🧪]
+    Roles --> R0[dc_audit_sacl]
+    Roles --> R1[runzero_explorer 🧪]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[runzero_explorer 🧪]
 ```
@@ -46,9 +47,17 @@ ansible-galaxy collection build --force && \
 
 | Role | Description |
 | ---- | ----------- |
+| [`dc_audit_sacl`](roles/dc_audit_sacl/README.md) | Configure SACL auditing on Domain Controllers for attack detection |
 | [`runzero_explorer`](roles/runzero_explorer/README.md) | Install the runZero explorer |
 
 <!-- ROLES TABLE END -->
+
+### DC Audit SACL
+
+Configures SACL entries and `auditpol` subcategories on a Windows Domain
+Controller so that DCSync-style replication attempts (and other Directory
+Service Access events) are audited. Windows Server 2019/2022 only; no
+molecule test coverage (needs a real AD forest).
 
 ### runZero Explorer
 

--- a/roles/dc_audit_sacl/README.md
+++ b/roles/dc_audit_sacl/README.md
@@ -1,0 +1,62 @@
+<!-- DOCSIBLE START -->
+# dc_audit_sacl
+
+## Description
+
+Configure SACL auditing on Domain Controllers for attack detection
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `dc_audit_sacl_replication_guids` | list | <code>&#91;&#93;</code> | No description |
+| `dc_audit_sacl_replication_guids.0` | dict | <code>{}</code> | No description |
+| `dc_audit_sacl_replication_guids.1` | dict | <code>{}</code> | No description |
+| `dc_audit_sacl_replication_guids.2` | dict | <code>{}</code> | No description |
+| `dc_audit_sacl_principal` | str | <code>S-1-1-0</code> | No description |
+| `dc_audit_sacl_flags` | str | <code>Success</code> | No description |
+| `dc_audit_sacl_ensure_auditpol` | bool | <code>True</code> | No description |
+| `dc_audit_sacl_subcategories` | list | <code>&#91;&#93;</code> | No description |
+| `dc_audit_sacl_subcategories.0` | str | <code>Directory Service Access</code> | No description |
+| `dc_audit_sacl_subcategories.1` | str | <code>Directory Service Changes</code> | No description |
+
+## Tasks
+
+### main.yml
+
+
+- **Check if host is a Domain Controller** (ansible.windows.win_feature_info)
+- **Set DC detection fact** (ansible.builtin.set_fact)
+- **Skip if not a Domain Controller** (ansible.builtin.debug) - Conditional
+- **Configure SACL auditing on Domain Controller** (block) - Conditional
+- **Configure auditpol for Directory Service Access** (ansible.windows.win_shell) - Conditional
+- **Get current domain DN** (ansible.windows.win_shell)
+- **Configure SACL for replication GUIDs (DCSync detection)** (ansible.windows.win_shell)
+- **Verify SACL configuration** (ansible.windows.win_shell)
+- **Display verification result** (ansible.builtin.debug)
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - dc_audit_sacl
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: l50
+- **License**: MIT
+
+## Platforms
+
+
+- Windows: 2019, 2022
+<!-- DOCSIBLE END -->

--- a/roles/dc_audit_sacl/defaults/main.yml
+++ b/roles/dc_audit_sacl/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# DC Audit SACL Configuration
+# Enables auditing for DCSync and other AD attack detection
+
+# GUIDs for replication rights (DCSync detection)
+dc_audit_sacl_replication_guids:
+  - name: "DS-Replication-Get-Changes"
+    guid: "1131f6aa-9c07-11d1-f79f-00c04fc2dcd2"
+  - name: "DS-Replication-Get-Changes-All"
+    guid: "1131f6ad-9c07-11d1-f79f-00c04fc2dcd2"
+  - name: "DS-Replication-Get-Changes-In-Filtered-Set"
+    guid: "89e95b76-444d-4c62-991a-0facbeda640c"
+
+# Principal to audit (Everyone by default for comprehensive coverage)
+dc_audit_sacl_principal: "S-1-1-0"  # Everyone SID
+
+# Audit flags
+dc_audit_sacl_flags: "Success"  # Success, Failure, or both
+
+# Also ensure auditpol is configured
+dc_audit_sacl_ensure_auditpol: true
+dc_audit_sacl_subcategories:
+  - "Directory Service Access"
+  - "Directory Service Changes"

--- a/roles/dc_audit_sacl/handlers/main.yml
+++ b/roles/dc_audit_sacl/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+# Handlers for dc_audit_sacl role
+# No handlers required - SACL changes take effect immediately

--- a/roles/dc_audit_sacl/meta/main.yml
+++ b/roles/dc_audit_sacl/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: dc_audit_sacl
+  namespace: l50
+  author: Jayson Grace
+  description: Configure SACL auditing on Domain Controllers for attack detection
+  company: l50
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+  galaxy_tags:
+    - windows
+    - activedirectory
+    - security
+    - auditing
+    - dcsync
+
+dependencies: []

--- a/roles/dc_audit_sacl/tasks/main.yml
+++ b/roles/dc_audit_sacl/tasks/main.yml
@@ -1,0 +1,92 @@
+---
+# DC Audit SACL Configuration
+# Configures SACL entries on domain objects for attack detection (DCSync, etc.)
+
+- name: Check if host is a Domain Controller
+  ansible.windows.win_feature_info:
+    name: AD-Domain-Services
+  register: dc_audit_sacl_adds_feature
+
+# win_feature_info.exists means the feature name was found in Windows' catalog (always true on Server)
+# We need to check if the feature is actually INSTALLED
+- name: Set DC detection fact
+  ansible.builtin.set_fact:
+    dc_audit_sacl_is_dc: "{{ dc_audit_sacl_adds_feature.features[0].installed | default(false) }}"
+
+- name: Skip if not a Domain Controller
+  ansible.builtin.debug:
+    msg: "Skipping dc_audit_sacl role - host is not a Domain Controller (AD-Domain-Services not installed)"
+  when: not dc_audit_sacl_is_dc
+
+- name: Configure SACL auditing on Domain Controller
+  when: dc_audit_sacl_is_dc
+  block:
+    - name: Configure auditpol for Directory Service Access
+      ansible.windows.win_shell: |
+        auditpol /set /subcategory:"{{ item }}" /success:enable
+      loop: "{{ dc_audit_sacl_subcategories }}"
+      when: dc_audit_sacl_ensure_auditpol
+      register: dc_audit_sacl_auditpol_result
+      changed_when: dc_audit_sacl_auditpol_result.rc == 0
+
+    - name: Get current domain DN
+      ansible.windows.win_shell: |
+        Import-Module ActiveDirectory
+        (Get-ADDomain).DistinguishedName
+      register: dc_audit_sacl_domain_dn
+      changed_when: false
+
+    - name: Configure SACL for replication GUIDs (DCSync detection)
+      ansible.windows.win_shell: |
+        Import-Module ActiveDirectory
+        $domainDN = "{{ dc_audit_sacl_domain_dn.stdout | trim }}"
+        $guid = [GUID]"{{ item.guid }}"
+        $principal = New-Object System.Security.Principal.SecurityIdentifier("{{ dc_audit_sacl_principal }}")
+
+        # Get current ACL with audit rules
+        $acl = Get-Acl -Path "AD:\$domainDN" -Audit
+
+        # Check if rule already exists
+        $existingRule = $acl.Audit | Where-Object {
+          $_.ObjectType -eq $guid -and
+          $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]) -eq $principal
+        }
+
+        if ($existingRule) {
+          Write-Host "SACL_EXISTS: {{ item.name }}"
+          exit 0
+        }
+
+        # Create and add audit rule
+        $auditRule = New-Object System.DirectoryServices.ActiveDirectoryAuditRule(
+          $principal,
+          [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight,
+          [System.Security.AccessControl.AuditFlags]::{{ dc_audit_sacl_flags }},
+          $guid
+        )
+        $acl.AddAuditRule($auditRule)
+        Set-Acl -Path "AD:\$domainDN" -AclObject $acl
+        Write-Host "SACL_ADDED: {{ item.name }}"
+      loop: "{{ dc_audit_sacl_replication_guids }}"
+      register: dc_audit_sacl_result
+      changed_when: "'SACL_ADDED' in dc_audit_sacl_result.stdout"
+
+    - name: Verify SACL configuration
+      ansible.windows.win_shell: |
+        Import-Module ActiveDirectory
+        $domainDN = "{{ dc_audit_sacl_domain_dn.stdout | trim }}"
+        $acl = Get-Acl -Path "AD:\$domainDN" -Audit
+        $replicationGuids = @(
+          "1131f6aa-9c07-11d1-f79f-00c04fc2dcd2",
+          "1131f6ad-9c07-11d1-f79f-00c04fc2dcd2",
+          "89e95b76-444d-4c62-991a-0facbeda640c"
+        )
+        $configured = $acl.Audit | Where-Object { $replicationGuids -contains $_.ObjectType.ToString() }
+        Write-Host "Configured SACL entries for DCSync detection: $($configured.Count)"
+        $configured | ForEach-Object { Write-Host "  - $($_.ObjectType)" }
+      register: dc_audit_sacl_verify_result
+      changed_when: false
+
+    - name: Display verification result
+      ansible.builtin.debug:
+        msg: "{{ dc_audit_sacl_verify_result.stdout_lines }}"


### PR DESCRIPTION
**Key Changes:**

- New Ansible role that configures SACL auditing on Windows Domain Controllers to detect DCSync-style replication attacks
- Targets the three critical replication GUIDs (`DS-Replication-Get-Changes`, `DS-Replication-Get-Changes-All`, `DS-Replication-Get-Changes-In-Filtered-Set`) used in DCSync attacks
- Role safely skips execution on non-DC hosts by checking whether `AD-Domain-Services` is actually installed before making any changes

**Added:**

- `dc_audit_sacl` role - Full role scaffold (`tasks/main.yml`, `defaults/main.yml`, `handlers/main.yml`, `meta/main.yml`) that configures SACL entries on the domain root object and enables `auditpol` subcategories for Directory Service Access and Directory Service Changes; targets Windows Server 2019/2022 only with no molecule test coverage (requires a real AD forest)
- Role documentation - `roles/dc_audit_sacl/README.md` documenting all default variables, task flow, example playbook, and platform support

**Changed:**

- Collection overview - Updated `README.md` to include `dc_audit_sacl` in the Mermaid diagram, roles table, and added a dedicated section describing its purpose and platform constraints alongside the existing `runzero_explorer` entry