### PR TITLE
feat: add aws_cloudwatch_agent ansible role

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ response, and system hardening.
 graph TD
     Collection[Ansible Collection]
     Collection --> Roles[⚙️ Roles]
-    Roles --> R0[dc_audit_sacl]
-    Roles --> R1[runzero_explorer 🧪]
-    Roles --> R2[sysmon]
+    Roles --> R0[aws_cloudwatch_agent]
+    Roles --> R1[dc_audit_sacl]
+    Roles --> R2[runzero_explorer 🧪]
+    Roles --> R3[sysmon]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[runzero_explorer 🧪]
 ```
@@ -48,11 +49,19 @@ ansible-galaxy collection build --force && \
 
 | Role | Description |
 | ---- | ----------- |
+| [`aws_cloudwatch_agent`](roles/aws_cloudwatch_agent/README.md) | Install and configure AWS CloudWatch Agent |
 | [`dc_audit_sacl`](roles/dc_audit_sacl/README.md) | Configure SACL auditing on Domain Controllers for attack detection |
 | [`runzero_explorer`](roles/runzero_explorer/README.md) | Install the runZero explorer |
 | [`sysmon`](roles/sysmon/README.md) | Install and configure Sysinternals Sysmon on Windows hosts |
 
 <!-- ROLES TABLE END -->
+
+### AWS CloudWatch Agent
+
+Installs and configures the [Amazon CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html)
+on Ubuntu/Debian and Windows hosts. Ships default CPU/disk/memory/netstat/process
+metrics with EC2 instance dimensions; override `aws_cloudwatch_agent_config` to
+tailor collection.
 
 ### DC Audit SACL
 

--- a/roles/aws_cloudwatch_agent/README.md
+++ b/roles/aws_cloudwatch_agent/README.md
@@ -1,0 +1,89 @@
+<!-- DOCSIBLE START -->
+# aws_cloudwatch_agent
+
+## Description
+
+Install and configure AWS CloudWatch Agent
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `aws_cloudwatch_agent_temp_dir` | str | <code>/tmp/cloudwatch_install</code> | No description |
+| `aws_cloudwatch_agent_linux_config_dir` | str | <code>/opt/aws/amazon-cloudwatch-agent/etc</code> | No description |
+| `aws_cloudwatch_agent_linux_log_dir` | str | <code>/var/log/amazon/amazon-cloudwatch-agent</code> | No description |
+| `aws_cloudwatch_agent_windows_temp_dir` | str | <code>C:\Windows\Temp</code> | No description |
+| `aws_cloudwatch_agent_windows_installer` | str | <code>amazon-cloudwatch-agent.msi</code> | No description |
+| `aws_cloudwatch_agent_windows_config_dir` | str | <code>C:\ProgramData\Amazon\AmazonCloudWatchAgent</code> | No description |
+| `aws_cloudwatch_agent_windows_log_dir` | str | <code>C:\ProgramData\Amazon\AmazonCloudWatchAgent\Logs</code> | No description |
+| `aws_cloudwatch_agent_config` | dict | <code>{}</code> | No description |
+| `aws_cloudwatch_agent_config.agent` | dict | <code>{}</code> | No description |
+| `aws_cloudwatch_agent_config.metrics` | dict | <code>{}</code> | No description |
+
+### Role Variables (main.yml)
+
+| Variable | Type | Value | Description |
+| -------- | ---- | ----- | ----------- |
+| `aws_cloudwatch_agent_deb_url` | str | `https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb` | No description |
+| `aws_cloudwatch_agent_win_url` | str | `https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi` | No description |
+
+## Tasks
+
+### linux.yml
+
+
+- **Set DEBIAN_FRONTEND to noninteractive** (ansible.builtin.lineinfile) - Conditional
+- **Create temporary directory for CloudWatch installation** (ansible.builtin.file)
+- **Download CloudWatch agent (Debian/Ubuntu)** (ansible.builtin.get_url) - Conditional
+- **Install CloudWatch agent (Debian/Ubuntu)** (ansible.builtin.apt) - Conditional
+- **Ensure CloudWatch Agent config directory exists** (ansible.builtin.file)
+- **Create CloudWatch Agent configuration** (ansible.builtin.template)
+- **Start CloudWatch Agent** (ansible.builtin.shell)
+- **Reload systemd** (ansible.builtin.systemd)
+- **Enable and start CloudWatch agent** (ansible.builtin.systemd)
+- **Clean up temporary files** (ansible.builtin.file)
+
+### main.yml
+
+
+- **Include Linux tasks** (ansible.builtin.include_tasks) - Conditional
+- **Include Windows tasks** (ansible.builtin.include_tasks) - Conditional
+
+### windows.yml
+
+
+- **Download CloudWatch agent installer (Windows)** (ansible.windows.win_get_url)
+- **Install CloudWatch agent (Windows)** (ansible.windows.win_package)
+- **Ensure CloudWatch Agent config directory exists** (ansible.windows.win_file)
+- **Create CloudWatch Agent configuration (Windows)** (ansible.windows.win_template)
+- **Start CloudWatch Agent (Windows)** (ansible.windows.win_shell)
+- **Make sure CloudWatch agent service is running (Windows)** (ansible.windows.win_service)
+- **Clean up temporary files (Windows)** (ansible.windows.win_file)
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - aws_cloudwatch_agent
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: l50
+- **License**: MIT
+
+## Platforms
+
+
+- Ubuntu: all
+- Debian: all
+- Windows: all
+<!-- DOCSIBLE END -->

--- a/roles/aws_cloudwatch_agent/defaults/main.yml
+++ b/roles/aws_cloudwatch_agent/defaults/main.yml
@@ -1,0 +1,61 @@
+---
+# General settings
+aws_cloudwatch_agent_temp_dir: "/tmp/cloudwatch_install"
+
+# Linux
+aws_cloudwatch_agent_linux_config_dir: "/opt/aws/amazon-cloudwatch-agent/etc"
+aws_cloudwatch_agent_linux_log_dir: "/var/log/amazon/amazon-cloudwatch-agent"
+
+# Windows
+aws_cloudwatch_agent_windows_temp_dir: "C:\\Windows\\Temp"
+aws_cloudwatch_agent_windows_installer: "amazon-cloudwatch-agent.msi"
+aws_cloudwatch_agent_windows_config_dir: "C:\\ProgramData\\Amazon\\AmazonCloudWatchAgent"
+aws_cloudwatch_agent_windows_log_dir: "C:\\ProgramData\\Amazon\\AmazonCloudWatchAgent\\Logs"
+
+# CloudWatch agent configuration
+aws_cloudwatch_agent_config:
+  agent:
+    metrics_collection_interval: 60
+    run_as_user: "root"
+  metrics:
+    metrics_collected:
+      cpu:
+        measurement:
+          - "cpu_usage_idle"
+          - "cpu_usage_iowait"
+          - "cpu_usage_user"
+          - "cpu_usage_system"
+        resources: ["*"]
+        totalcpu: true
+      disk:
+        measurement:
+          - "used_percent"
+          - "inodes_free"
+        resources: ["*"]
+      diskio:
+        measurement:
+          - "io_time"
+          - "write_bytes"
+          - "read_bytes"
+          - "writes"
+          - "reads"
+        resources: ["*"]
+      mem:
+        measurement:
+          - "mem_used_percent"
+      swap:
+        measurement:
+          - "swap_used_percent"
+      netstat:
+        measurement:
+          - "tcp_established"
+          - "tcp_time_wait"
+      processes:
+        measurement:
+          - "running"
+          - "blocked"
+          - "zombies"
+    append_dimensions:
+      InstanceId: "${aws:InstanceId}"
+      InstanceType: "${aws:InstanceType}"
+      AutoScalingGroupName: "${aws:AutoScalingGroupName}"

--- a/roles/aws_cloudwatch_agent/handlers/main.yml
+++ b/roles/aws_cloudwatch_agent/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Restart cloudwatch_agent (Linux)
+  ansible.builtin.systemd:
+    name: amazon-cloudwatch-agent
+    state: restarted
+  become: true
+  when: ansible_os_family != 'Windows'
+
+- name: Restart cloudwatch_agent (Windows)
+  ansible.windows.win_service:
+    name: AmazonCloudWatchAgent
+    state: restarted
+  when: ansible_os_family == 'Windows'

--- a/roles/aws_cloudwatch_agent/meta/main.yml
+++ b/roles/aws_cloudwatch_agent/meta/main.yml
@@ -1,0 +1,27 @@
+---
+galaxy_info:
+  role_name: aws_cloudwatch_agent
+  namespace: l50
+  author: Jayson Grace
+  description: Install and configure AWS CloudWatch Agent
+  company: l50
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Windows
+      versions:
+        - all
+  galaxy_tags:
+    - aws
+    - cloudwatch
+    - linux
+    - monitoring
+    - windows
+
+dependencies: []

--- a/roles/aws_cloudwatch_agent/tasks/linux.yml
+++ b/roles/aws_cloudwatch_agent/tasks/linux.yml
@@ -1,0 +1,74 @@
+---
+- name: Set DEBIAN_FRONTEND to noninteractive
+  ansible.builtin.lineinfile:
+    path: /etc/environment
+    line: 'DEBIAN_FRONTEND=noninteractive'
+    create: true
+    mode: '0644'
+  become: true
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Create temporary directory for CloudWatch installation
+  ansible.builtin.file:
+    path: "{{ aws_cloudwatch_agent_temp_dir }}"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Download CloudWatch agent (Debian/Ubuntu)
+  ansible.builtin.get_url:
+    url: "{{ aws_cloudwatch_agent_deb_url }}"
+    dest: "{{ aws_cloudwatch_agent_temp_dir }}/amazon-cloudwatch-agent.deb"
+    mode: '0644'
+  become: true
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Install CloudWatch agent (Debian/Ubuntu)
+  ansible.builtin.apt:
+    deb: "{{ aws_cloudwatch_agent_temp_dir }}/amazon-cloudwatch-agent.deb"
+    state: present
+  become: true
+  when: ansible_facts['os_family'] == 'Debian'
+
+- name: Ensure CloudWatch Agent config directory exists
+  ansible.builtin.file:
+    path: "{{ aws_cloudwatch_agent_linux_config_dir }}"
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Create CloudWatch Agent configuration
+  ansible.builtin.template:
+    src: amazon-cloudwatch-agent.json.j2
+    dest: "{{ aws_cloudwatch_agent_linux_config_dir }}/amazon-cloudwatch-agent.json"
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Restart cloudwatch_agent (Linux)
+
+- name: Start CloudWatch Agent
+  ansible.builtin.shell: >
+    /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c
+    file:{{ aws_cloudwatch_agent_linux_config_dir }}/amazon-cloudwatch-agent.json
+  become: true
+  args:
+    creates: "/var/run/amazon-cloudwatch-agent.pid"
+
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+
+- name: Enable and start CloudWatch agent
+  ansible.builtin.systemd:
+    name: amazon-cloudwatch-agent
+    enabled: true
+    state: started
+  become: true
+
+- name: Clean up temporary files
+  ansible.builtin.file:
+    path: "{{ aws_cloudwatch_agent_temp_dir }}"
+    state: absent
+  become: true

--- a/roles/aws_cloudwatch_agent/tasks/main.yml
+++ b/roles/aws_cloudwatch_agent/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Include Linux tasks
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != 'Windows'
+
+- name: Include Windows tasks
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == 'Windows'

--- a/roles/aws_cloudwatch_agent/tasks/windows.yml
+++ b/roles/aws_cloudwatch_agent/tasks/windows.yml
@@ -1,0 +1,39 @@
+---
+- name: Download CloudWatch agent installer (Windows)
+  ansible.windows.win_get_url:
+    url: "{{ aws_cloudwatch_agent_win_url }}"
+    dest: "{{ aws_cloudwatch_agent_windows_temp_dir }}\\{{ aws_cloudwatch_agent_windows_installer }}"
+
+- name: Install CloudWatch agent (Windows)
+  ansible.windows.win_package:
+    path: "{{ aws_cloudwatch_agent_windows_temp_dir }}\\{{ aws_cloudwatch_agent_windows_installer }}"
+    arguments: /quiet
+    state: present
+
+- name: Ensure CloudWatch Agent config directory exists
+  ansible.windows.win_file:
+    path: "{{ aws_cloudwatch_agent_windows_config_dir }}"
+    state: directory
+
+- name: Create CloudWatch Agent configuration (Windows)
+  ansible.windows.win_template:
+    src: amazon-cloudwatch-agent.json.j2
+    dest: "{{ aws_cloudwatch_agent_windows_config_dir }}\\amazon-cloudwatch-agent.json"
+  notify: Restart cloudwatch_agent (Windows)
+
+- name: Start CloudWatch Agent (Windows)
+  ansible.windows.win_shell: |
+    & "C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1" -a fetch-config -m ec2 -s -c file:"{{ aws_cloudwatch_agent_windows_config_dir }}\amazon-cloudwatch-agent.json"
+  args:
+    creates: "{{ aws_cloudwatch_agent_windows_config_dir }}\\amazon-cloudwatch-agent.json.status"
+
+- name: Make sure CloudWatch agent service is running (Windows)
+  ansible.windows.win_service:
+    name: AmazonCloudWatchAgent
+    start_mode: auto
+    state: started
+
+- name: Clean up temporary files (Windows)
+  ansible.windows.win_file:
+    path: "{{ aws_cloudwatch_agent_windows_temp_dir }}\\{{ aws_cloudwatch_agent_windows_installer }}"
+    state: absent

--- a/roles/aws_cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
+++ b/roles/aws_cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
@@ -1,0 +1,1 @@
+{{ aws_cloudwatch_agent_config | to_nice_json }}

--- a/roles/aws_cloudwatch_agent/vars/main.yml
+++ b/roles/aws_cloudwatch_agent/vars/main.yml
@@ -1,0 +1,6 @@
+---
+# Linux
+aws_cloudwatch_agent_deb_url: "https://s3.amazonaws.com/amazoncloudwatch-agent/debian/amd64/latest/amazon-cloudwatch-agent.deb"
+
+# Windows
+aws_cloudwatch_agent_win_url: "https://s3.amazonaws.com/amazoncloudwatch-agent/windows/amd64/latest/amazon-cloudwatch-agent.msi"


### PR DESCRIPTION
**Key Changes:**

- Introduced a new `aws_cloudwatch_agent` Ansible role supporting Ubuntu/Debian and Windows hosts
- Ships a comprehensive default metrics configuration covering CPU, disk, memory, netstat, and process metrics with EC2 instance dimensions
- Role is fully cross-platform, using native Ansible modules for both Linux (`ansible.builtin`) and Windows (`ansible.windows`)
- Updated collection README and diagram to reflect the new role

**Added:**

- Cross-platform CloudWatch Agent role - New `roles/aws_cloudwatch_agent/` role that installs and configures the Amazon CloudWatch Agent on Debian/Ubuntu (via `.deb` package) and Windows (via `.msi` installer), with OS-family-based task dispatch in `tasks/main.yml`
- Default metrics configuration - `defaults/main.yml` ships a ready-to-use `aws_cloudwatch_agent_config` dict collecting CPU idle/iowait/user/system, disk usage and inodes, disk I/O, memory, swap, netstat TCP states, and process states, with EC2 `InstanceId`, `InstanceType`, and `AutoScalingGroupName` dimensions appended automatically
- Jinja2 config template - `templates/amazon-cloudwatch-agent.json.j2` renders the `aws_cloudwatch_agent_config` variable directly to JSON using `to_nice_json`, making the config fully overridable by callers
- Service handlers - `handlers/main.yml` defines restart handlers for both the `amazon-cloudwatch-agent` systemd unit (Linux) and the `AmazonCloudWatchAgent` Windows service, triggered on configuration changes
- Role metadata and documentation - `meta/main.yml` declares Galaxy metadata (namespace `l50`, MIT license, Ansible >= 2.14, Ubuntu/Debian/Windows platforms) and `roles/aws_cloudwatch_agent/README.md` documents all variables, tasks, and an example playbook

**Changed:**

- Collection README updated - Added `aws_cloudwatch_agent` to the Mermaid architecture diagram, the roles reference table, and a new prose section describing the role's purpose and the `aws_cloudwatch_agent_config` override pattern