### PR TITLE
feat: add aws_ssm_agent ansible role for cross-platform ssm management

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ graph TD
     Collection --> Roles[⚙️ Roles]
     Roles --> R0[dc_audit_sacl]
     Roles --> R1[runzero_explorer 🧪]
+    Roles --> R2[sysmon]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[runzero_explorer 🧪]
 ```
@@ -49,6 +50,7 @@ ansible-galaxy collection build --force && \
 | ---- | ----------- |
 | [`dc_audit_sacl`](roles/dc_audit_sacl/README.md) | Configure SACL auditing on Domain Controllers for attack detection |
 | [`runzero_explorer`](roles/runzero_explorer/README.md) | Install the runZero explorer |
+| [`sysmon`](roles/sysmon/README.md) | Install and configure Sysinternals Sysmon on Windows hosts |
 
 <!-- ROLES TABLE END -->
 
@@ -62,6 +64,12 @@ molecule test coverage (needs a real AD forest).
 ### runZero Explorer
 
 Installs and configures [runZero Explorer](https://console.runzero.com/deploy/download/explorers).
+
+### Sysmon
+
+Installs [Sysinternals Sysmon](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon)
+on Windows hosts with the [SwiftOnSecurity sysmon-config](https://github.com/SwiftOnSecurity/sysmon-config)
+baseline. Windows-only; no Linux/molecule test coverage.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ response, and system hardening.
 graph TD
     Collection[Ansible Collection]
     Collection --> Roles[⚙️ Roles]
-    Roles --> R0[dc_audit_sacl]
-    Roles --> R1[runzero_explorer 🧪]
-    Roles --> R2[sysmon]
+    Roles --> R0[aws_ssm_agent]
+    Roles --> R1[dc_audit_sacl]
+    Roles --> R2[runzero_explorer 🧪]
+    Roles --> R3[sysmon]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[runzero_explorer 🧪]
 ```
@@ -48,11 +49,19 @@ ansible-galaxy collection build --force && \
 
 | Role | Description |
 | ---- | ----------- |
+| [`aws_ssm_agent`](roles/aws_ssm_agent/README.md) | Install and configure AWS SSM Agent |
 | [`dc_audit_sacl`](roles/dc_audit_sacl/README.md) | Configure SACL auditing on Domain Controllers for attack detection |
 | [`runzero_explorer`](roles/runzero_explorer/README.md) | Install the runZero explorer |
 | [`sysmon`](roles/sysmon/README.md) | Install and configure Sysinternals Sysmon on Windows hosts |
 
 <!-- ROLES TABLE END -->
+
+### AWS SSM Agent
+
+Installs and configures the [Amazon SSM Agent](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html)
+on Ubuntu/Debian and Windows hosts so instances can be managed via AWS Systems
+Manager (Session Manager, Run Command, Patch Manager). Optionally applies a
+systemd `MemoryMax` cap to protect against SSM OOM eating other workloads.
 
 ### DC Audit SACL
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ response, and system hardening.
 graph TD
     Collection[Ansible Collection]
     Collection --> Roles[⚙️ Roles]
-    Roles --> R0[runzero_explorer 🧪]
+    Roles --> R0[dc_audit_sacl]
+    Roles --> R1[runzero_explorer 🧪]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[runzero_explorer 🧪]
 ```
@@ -46,9 +47,17 @@ ansible-galaxy collection build --force && \
 
 | Role | Description |
 | ---- | ----------- |
+| [`dc_audit_sacl`](roles/dc_audit_sacl/README.md) | Configure SACL auditing on Domain Controllers for attack detection |
 | [`runzero_explorer`](roles/runzero_explorer/README.md) | Install the runZero explorer |
 
 <!-- ROLES TABLE END -->
+
+### DC Audit SACL
+
+Configures SACL entries and `auditpol` subcategories on a Windows Domain
+Controller so that DCSync-style replication attempts (and other Directory
+Service Access events) are audited. Windows Server 2019/2022 only; no
+molecule test coverage (needs a real AD forest).
 
 ### runZero Explorer
 

--- a/roles/aws_ssm_agent/README.md
+++ b/roles/aws_ssm_agent/README.md
@@ -1,0 +1,89 @@
+<!-- DOCSIBLE START -->
+# aws_ssm_agent
+
+## Description
+
+Install and configure AWS SSM Agent
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `aws_ssm_agent_temp_dir` | str | <code>/tmp/ssm_install</code> | No description |
+| `aws_ssm_agent_aws_region` | str | <code>us-east-1</code> | No description |
+| `aws_ssm_agent_oom_protect` | bool | <code>True</code> | No description |
+| `aws_ssm_agent_memory_max` | str | <code>512M</code> | No description |
+
+### Role Variables (main.yml)
+
+| Variable | Type | Value | Description |
+| -------- | ---- | ----- | ----------- |
+| `aws_ssm_agent_linux_install_url` | str | `https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb` | No description |
+| `aws_ssm_agent_install_packages` | list | `[]` | No description |
+| `aws_ssm_agent_install_packages.0` | str | `systemd` | No description |
+| `aws_ssm_agent_windows_install_url` | str | `https://amazon-ssm-{{ aws_ssm_agent_aws_region | default('us-east-1') }}.s3.amazonaws.com/latest/windows_amd64/AmazonSSMAgentSetup.exe` | No description |
+| `aws_ssm_agent_windows_temp_dir` | str | `C:\Windows\Temp` | No description |
+| `aws_ssm_agent_windows_installer` | str | `SSMAgent_latest.exe` | No description |
+
+## Tasks
+
+### linux.yml
+
+
+- **Check if SSM agent is installed via snap** (ansible.builtin.command)
+- **Set DEBIAN_FRONTEND to noninteractive** (ansible.builtin.lineinfile) - Conditional
+- **Install packages** (ansible.builtin.package) - Conditional
+- **Check if SSM agent is already installed via dpkg** (ansible.builtin.command) - Conditional
+- **Create temporary directory for SSM installation** (ansible.builtin.file) - Conditional
+- **Download SSM agent** (ansible.builtin.get_url) - Conditional
+- **Install SSM agent (Debian/Ubuntu)** (ansible.builtin.apt) - Conditional
+- **Create SSM agent systemd override directory** (ansible.builtin.file) - Conditional
+- **Deploy SSM agent OOM protection override** (ansible.builtin.template) - Conditional
+- **Reload systemd** (ansible.builtin.systemd) - Conditional
+- **Enable and start SSM agent** (ansible.builtin.systemd) - Conditional
+- **Refresh snap SSM agent** (ansible.builtin.command) - Conditional
+- **Ensure snap SSM agent service is running** (ansible.builtin.command) - Conditional
+- **Clean up temporary files** (ansible.builtin.file) - Conditional
+
+### main.yml
+
+
+- **Include Linux tasks** (ansible.builtin.include_tasks) - Conditional
+- **Include Windows tasks** (ansible.builtin.include_tasks) - Conditional
+
+### windows.yml
+
+
+- **Check if SSM agent service is already installed (Windows)** (ansible.windows.win_service)
+- **Download SSM agent installer (Windows)** (ansible.windows.win_get_url) - Conditional
+- **Install SSM agent (Windows)** (ansible.windows.win_package) - Conditional
+- **Make sure SSM agent service is running (Windows)** (ansible.windows.win_service)
+- **Clean up temporary files (Windows)** (ansible.windows.win_file) - Conditional
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - aws_ssm_agent
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: l50
+- **License**: MIT
+
+## Platforms
+
+
+- Ubuntu: all
+- Debian: all
+- Windows: all
+<!-- DOCSIBLE END -->

--- a/roles/aws_ssm_agent/defaults/main.yml
+++ b/roles/aws_ssm_agent/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# General settings
+aws_ssm_agent_temp_dir: "/tmp/ssm_install"
+aws_ssm_agent_aws_region: "us-east-1"
+
+# OOM protection — cap SSM agent memory and lower its OOM score so the kernel
+# kills worker tool processes (netexec, hashcat, nmap) instead of SSM.
+aws_ssm_agent_oom_protect: true
+aws_ssm_agent_memory_max: "512M"

--- a/roles/aws_ssm_agent/handlers/main.yml
+++ b/roles/aws_ssm_agent/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Restart ssm_agent (Linux)
+  ansible.builtin.systemd:
+    name: amazon-ssm-agent
+    state: restarted
+  become: true
+  when: ansible_os_family != 'Windows'
+
+- name: Restart ssm_agent (Windows)
+  ansible.windows.win_service:
+    name: AmazonSSMAgent
+    state: restarted
+  when: ansible_os_family == 'Windows'

--- a/roles/aws_ssm_agent/meta/main.yml
+++ b/roles/aws_ssm_agent/meta/main.yml
@@ -1,0 +1,27 @@
+---
+galaxy_info:
+  role_name: aws_ssm_agent
+  namespace: l50
+  author: Jayson Grace
+  description: Install and configure AWS SSM Agent
+  company: l50
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+    - name: Windows
+      versions:
+        - all
+  galaxy_tags:
+    - aws
+    - linux
+    - monitoring
+    - ssm
+    - windows
+
+dependencies: []

--- a/roles/aws_ssm_agent/tasks/linux.yml
+++ b/roles/aws_ssm_agent/tasks/linux.yml
@@ -1,0 +1,130 @@
+---
+- name: Check if SSM agent is installed via snap
+  ansible.builtin.command:
+    cmd: snap list amazon-ssm-agent
+  register: aws_ssm_agent_snap_check
+  changed_when: false
+  failed_when: false
+  become: true
+
+- name: Set DEBIAN_FRONTEND to noninteractive
+  ansible.builtin.lineinfile:
+    path: /etc/environment
+    line: 'DEBIAN_FRONTEND=noninteractive'
+    create: true
+    mode: '0644'
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - aws_ssm_agent_snap_check.rc != 0
+
+- name: Install packages
+  become: true
+  ansible.builtin.package:
+    name: "{{ aws_ssm_agent_install_packages }}"
+    state: present
+    update_cache: true
+  when:
+    - ansible_os_family in ['Debian']
+    - aws_ssm_agent_snap_check.rc != 0
+  tags: packages
+
+- name: Check if SSM agent is already installed via dpkg
+  ansible.builtin.command:
+    cmd: dpkg -s amazon-ssm-agent
+  register: aws_ssm_agent_dpkg_check
+  changed_when: false
+  failed_when: false
+  become: true
+  when: aws_ssm_agent_snap_check.rc != 0
+
+- name: Create temporary directory for SSM installation
+  ansible.builtin.file:
+    path: "{{ aws_ssm_agent_temp_dir }}"
+    state: directory
+    mode: '0755'
+  become: true
+  when:
+    - aws_ssm_agent_snap_check.rc != 0
+    - aws_ssm_agent_dpkg_check.rc != 0
+
+- name: Download SSM agent
+  ansible.builtin.get_url:
+    url: "{{ aws_ssm_agent_linux_install_url }}"
+    dest: "{{ aws_ssm_agent_temp_dir }}/amazon-ssm-agent.deb"
+    mode: '0644'
+  become: true
+  when:
+    - aws_ssm_agent_snap_check.rc != 0
+    - aws_ssm_agent_dpkg_check.rc != 0
+
+- name: Install SSM agent (Debian/Ubuntu)
+  ansible.builtin.apt:
+    deb: "{{ aws_ssm_agent_temp_dir }}/amazon-ssm-agent.deb"
+    state: present
+  become: true
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - aws_ssm_agent_snap_check.rc != 0
+    - aws_ssm_agent_dpkg_check.rc != 0
+
+- name: Create SSM agent systemd override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/amazon-ssm-agent.service.d
+    state: directory
+    mode: '0755'
+  become: true
+  when:
+    - aws_ssm_agent_snap_check.rc != 0
+    - aws_ssm_agent_oom_protect | default(true)
+
+- name: Deploy SSM agent OOM protection override
+  ansible.builtin.template:
+    src: ssm-oom-protect.conf.j2
+    dest: /etc/systemd/system/amazon-ssm-agent.service.d/oom-protect.conf
+    mode: '0644'
+  become: true
+  when:
+    - aws_ssm_agent_snap_check.rc != 0
+    - aws_ssm_agent_oom_protect | default(true)
+  notify:
+    - Restart ssm_agent (Linux)
+
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+  when: aws_ssm_agent_snap_check.rc != 0
+
+- name: Enable and start SSM agent
+  ansible.builtin.systemd:
+    name: amazon-ssm-agent
+    enabled: true
+    state: started
+  become: true
+  when: aws_ssm_agent_snap_check.rc != 0
+
+- name: Refresh snap SSM agent
+  ansible.builtin.command:
+    cmd: snap refresh amazon-ssm-agent
+  changed_when: false
+  failed_when: false
+  become: true
+  when: aws_ssm_agent_snap_check.rc == 0
+
+- name: Ensure snap SSM agent service is running
+  ansible.builtin.command:
+    cmd: snap start amazon-ssm-agent
+  changed_when: false
+  failed_when: false
+  become: true
+  when: aws_ssm_agent_snap_check.rc == 0
+
+- name: Clean up temporary files
+  ansible.builtin.file:
+    path: "{{ aws_ssm_agent_temp_dir }}"
+    state: absent
+  become: true
+  when:
+    - aws_ssm_agent_snap_check.rc != 0
+    - aws_ssm_agent_dpkg_check.rc != 0

--- a/roles/aws_ssm_agent/tasks/main.yml
+++ b/roles/aws_ssm_agent/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Include Linux tasks
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != 'Windows'
+
+- name: Include Windows tasks
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == 'Windows'

--- a/roles/aws_ssm_agent/tasks/windows.yml
+++ b/roles/aws_ssm_agent/tasks/windows.yml
@@ -1,0 +1,33 @@
+---
+- name: Check if SSM agent service is already installed (Windows)
+  ansible.windows.win_service:
+    name: AmazonSSMAgent
+  register: aws_ssm_agent_service
+  failed_when: false
+
+- name: Download SSM agent installer (Windows)
+  ansible.windows.win_get_url:
+    url: "{{ aws_ssm_agent_windows_install_url }}"
+    dest: "{{ aws_ssm_agent_windows_temp_dir }}\\{{ aws_ssm_agent_windows_installer }}"
+  when: not (aws_ssm_agent_service.exists | default(false))
+
+- name: Install SSM agent (Windows)
+  ansible.windows.win_package:
+    path: "{{ aws_ssm_agent_windows_temp_dir }}\\{{ aws_ssm_agent_windows_installer }}"
+    arguments: /S
+    state: present
+  when: not (aws_ssm_agent_service.exists | default(false))
+
+- name: Make sure SSM agent service is running (Windows)
+  ansible.windows.win_service:
+    name: AmazonSSMAgent
+    start_mode: auto
+    state: started
+
+- name: Clean up temporary files (Windows)
+  ansible.windows.win_file:
+    path: "{{ aws_ssm_agent_windows_temp_dir }}\\{{ aws_ssm_agent_windows_installer }}"
+    state: absent
+  register: aws_ssm_agent_cleanup
+  failed_when: false
+  when: not (aws_ssm_agent_service.exists | default(false))

--- a/roles/aws_ssm_agent/templates/check-ssm-agent.ps1.j2
+++ b/roles/aws_ssm_agent/templates/check-ssm-agent.ps1.j2
@@ -1,0 +1,37 @@
+# Script to check and restart SSM Agent if not running
+$ErrorActionPreference = "Stop"
+$LogFile = "C:\Program Files\Amazon\SSM\logs\ssm-agent-check.log"
+
+function Write-Log {
+    param (
+        [string]$Message
+    )
+    $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    "$Timestamp - $Message" | Out-File -Append -FilePath $LogFile
+}
+
+# Check if SSM Agent service is running
+$service = Get-Service -Name AmazonSSMAgent -ErrorAction SilentlyContinue
+
+if ($null -eq $service) {
+    Write-Log "ERROR: AmazonSSMAgent service not found"
+    exit 1
+}
+
+if ($service.Status -ne "Running") {
+    Write-Log "WARNING: SSM Agent is not running, restarting it"
+    try {
+        Restart-Service -Name AmazonSSMAgent -Force
+        Start-Sleep -Seconds 3
+        $service = Get-Service -Name AmazonSSMAgent
+        if ($service.Status -eq "Running") {
+            Write-Log "SUCCESS: SSM Agent restarted successfully"
+        } else {
+            Write-Log "ERROR: Failed to restart SSM Agent service"
+        }
+    } catch {
+        Write-Log "ERROR: Exception when restarting SSM Agent - $_"
+    }
+} else {
+    Write-Log "INFO: SSM Agent service is running correctly"
+}

--- a/roles/aws_ssm_agent/templates/check-ssm-agent.sh.j2
+++ b/roles/aws_ssm_agent/templates/check-ssm-agent.sh.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+# Check if SSM Agent is running
+if ! systemctl is-active amazon-ssm-agent >/dev/null 2>&1; then
+  echo "[$(date)] WARNING: SSM Agent is not running, restarting it"
+  systemctl restart amazon-ssm-agent
+fi

--- a/roles/aws_ssm_agent/templates/ssm-oom-protect.conf.j2
+++ b/roles/aws_ssm_agent/templates/ssm-oom-protect.conf.j2
@@ -1,0 +1,8 @@
+# OOMScoreAdjust: survive system-wide OOM when Ares workers exhaust memory.
+# Children (RunCommand, Session Manager) inherit this — fine here since heavy
+# subprocesses run under a separate unit.
+# MemoryMax: cgroup self-cap (containment for SSM leaks). Cgroup-local OOM
+# ignores OOMScoreAdjust, so the two are independent protections.
+[Service]
+OOMScoreAdjust=-900
+MemoryMax={{ aws_ssm_agent_memory_max }}

--- a/roles/aws_ssm_agent/vars/main.yml
+++ b/roles/aws_ssm_agent/vars/main.yml
@@ -1,0 +1,10 @@
+---
+# Linux
+aws_ssm_agent_linux_install_url: "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb"
+aws_ssm_agent_install_packages:
+  - systemd
+
+# Windows
+aws_ssm_agent_windows_install_url: "https://amazon-ssm-{{ aws_ssm_agent_aws_region | default('us-east-1') }}.s3.amazonaws.com/latest/windows_amd64/AmazonSSMAgentSetup.exe"
+aws_ssm_agent_windows_temp_dir: "C:\\Windows\\Temp"
+aws_ssm_agent_windows_installer: "SSMAgent_latest.exe"

--- a/roles/dc_audit_sacl/README.md
+++ b/roles/dc_audit_sacl/README.md
@@ -1,0 +1,62 @@
+<!-- DOCSIBLE START -->
+# dc_audit_sacl
+
+## Description
+
+Configure SACL auditing on Domain Controllers for attack detection
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `dc_audit_sacl_replication_guids` | list | <code>&#91;&#93;</code> | No description |
+| `dc_audit_sacl_replication_guids.0` | dict | <code>{}</code> | No description |
+| `dc_audit_sacl_replication_guids.1` | dict | <code>{}</code> | No description |
+| `dc_audit_sacl_replication_guids.2` | dict | <code>{}</code> | No description |
+| `dc_audit_sacl_principal` | str | <code>S-1-1-0</code> | No description |
+| `dc_audit_sacl_flags` | str | <code>Success</code> | No description |
+| `dc_audit_sacl_ensure_auditpol` | bool | <code>True</code> | No description |
+| `dc_audit_sacl_subcategories` | list | <code>&#91;&#93;</code> | No description |
+| `dc_audit_sacl_subcategories.0` | str | <code>Directory Service Access</code> | No description |
+| `dc_audit_sacl_subcategories.1` | str | <code>Directory Service Changes</code> | No description |
+
+## Tasks
+
+### main.yml
+
+
+- **Check if host is a Domain Controller** (ansible.windows.win_feature_info)
+- **Set DC detection fact** (ansible.builtin.set_fact)
+- **Skip if not a Domain Controller** (ansible.builtin.debug) - Conditional
+- **Configure SACL auditing on Domain Controller** (block) - Conditional
+- **Configure auditpol for Directory Service Access** (ansible.windows.win_shell) - Conditional
+- **Get current domain DN** (ansible.windows.win_shell)
+- **Configure SACL for replication GUIDs (DCSync detection)** (ansible.windows.win_shell)
+- **Verify SACL configuration** (ansible.windows.win_shell)
+- **Display verification result** (ansible.builtin.debug)
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - dc_audit_sacl
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: l50
+- **License**: MIT
+
+## Platforms
+
+
+- Windows: 2019, 2022
+<!-- DOCSIBLE END -->

--- a/roles/dc_audit_sacl/defaults/main.yml
+++ b/roles/dc_audit_sacl/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# DC Audit SACL Configuration
+# Enables auditing for DCSync and other AD attack detection
+
+# GUIDs for replication rights (DCSync detection)
+dc_audit_sacl_replication_guids:
+  - name: "DS-Replication-Get-Changes"
+    guid: "1131f6aa-9c07-11d1-f79f-00c04fc2dcd2"
+  - name: "DS-Replication-Get-Changes-All"
+    guid: "1131f6ad-9c07-11d1-f79f-00c04fc2dcd2"
+  - name: "DS-Replication-Get-Changes-In-Filtered-Set"
+    guid: "89e95b76-444d-4c62-991a-0facbeda640c"
+
+# Principal to audit (Everyone by default for comprehensive coverage)
+dc_audit_sacl_principal: "S-1-1-0"  # Everyone SID
+
+# Audit flags
+dc_audit_sacl_flags: "Success"  # Success, Failure, or both
+
+# Also ensure auditpol is configured
+dc_audit_sacl_ensure_auditpol: true
+dc_audit_sacl_subcategories:
+  - "Directory Service Access"
+  - "Directory Service Changes"

--- a/roles/dc_audit_sacl/handlers/main.yml
+++ b/roles/dc_audit_sacl/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+# Handlers for dc_audit_sacl role
+# No handlers required - SACL changes take effect immediately

--- a/roles/dc_audit_sacl/meta/main.yml
+++ b/roles/dc_audit_sacl/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: dc_audit_sacl
+  namespace: l50
+  author: Jayson Grace
+  description: Configure SACL auditing on Domain Controllers for attack detection
+  company: l50
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+  galaxy_tags:
+    - windows
+    - activedirectory
+    - security
+    - auditing
+    - dcsync
+
+dependencies: []

--- a/roles/dc_audit_sacl/tasks/main.yml
+++ b/roles/dc_audit_sacl/tasks/main.yml
@@ -1,0 +1,92 @@
+---
+# DC Audit SACL Configuration
+# Configures SACL entries on domain objects for attack detection (DCSync, etc.)
+
+- name: Check if host is a Domain Controller
+  ansible.windows.win_feature_info:
+    name: AD-Domain-Services
+  register: dc_audit_sacl_adds_feature
+
+# win_feature_info.exists means the feature name was found in Windows' catalog (always true on Server)
+# We need to check if the feature is actually INSTALLED
+- name: Set DC detection fact
+  ansible.builtin.set_fact:
+    dc_audit_sacl_is_dc: "{{ dc_audit_sacl_adds_feature.features[0].installed | default(false) }}"
+
+- name: Skip if not a Domain Controller
+  ansible.builtin.debug:
+    msg: "Skipping dc_audit_sacl role - host is not a Domain Controller (AD-Domain-Services not installed)"
+  when: not dc_audit_sacl_is_dc
+
+- name: Configure SACL auditing on Domain Controller
+  when: dc_audit_sacl_is_dc
+  block:
+    - name: Configure auditpol for Directory Service Access
+      ansible.windows.win_shell: |
+        auditpol /set /subcategory:"{{ item }}" /success:enable
+      loop: "{{ dc_audit_sacl_subcategories }}"
+      when: dc_audit_sacl_ensure_auditpol
+      register: dc_audit_sacl_auditpol_result
+      changed_when: dc_audit_sacl_auditpol_result.rc == 0
+
+    - name: Get current domain DN
+      ansible.windows.win_shell: |
+        Import-Module ActiveDirectory
+        (Get-ADDomain).DistinguishedName
+      register: dc_audit_sacl_domain_dn
+      changed_when: false
+
+    - name: Configure SACL for replication GUIDs (DCSync detection)
+      ansible.windows.win_shell: |
+        Import-Module ActiveDirectory
+        $domainDN = "{{ dc_audit_sacl_domain_dn.stdout | trim }}"
+        $guid = [GUID]"{{ item.guid }}"
+        $principal = New-Object System.Security.Principal.SecurityIdentifier("{{ dc_audit_sacl_principal }}")
+
+        # Get current ACL with audit rules
+        $acl = Get-Acl -Path "AD:\$domainDN" -Audit
+
+        # Check if rule already exists
+        $existingRule = $acl.Audit | Where-Object {
+          $_.ObjectType -eq $guid -and
+          $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]) -eq $principal
+        }
+
+        if ($existingRule) {
+          Write-Host "SACL_EXISTS: {{ item.name }}"
+          exit 0
+        }
+
+        # Create and add audit rule
+        $auditRule = New-Object System.DirectoryServices.ActiveDirectoryAuditRule(
+          $principal,
+          [System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight,
+          [System.Security.AccessControl.AuditFlags]::{{ dc_audit_sacl_flags }},
+          $guid
+        )
+        $acl.AddAuditRule($auditRule)
+        Set-Acl -Path "AD:\$domainDN" -AclObject $acl
+        Write-Host "SACL_ADDED: {{ item.name }}"
+      loop: "{{ dc_audit_sacl_replication_guids }}"
+      register: dc_audit_sacl_result
+      changed_when: "'SACL_ADDED' in dc_audit_sacl_result.stdout"
+
+    - name: Verify SACL configuration
+      ansible.windows.win_shell: |
+        Import-Module ActiveDirectory
+        $domainDN = "{{ dc_audit_sacl_domain_dn.stdout | trim }}"
+        $acl = Get-Acl -Path "AD:\$domainDN" -Audit
+        $replicationGuids = @(
+          "1131f6aa-9c07-11d1-f79f-00c04fc2dcd2",
+          "1131f6ad-9c07-11d1-f79f-00c04fc2dcd2",
+          "89e95b76-444d-4c62-991a-0facbeda640c"
+        )
+        $configured = $acl.Audit | Where-Object { $replicationGuids -contains $_.ObjectType.ToString() }
+        Write-Host "Configured SACL entries for DCSync detection: $($configured.Count)"
+        $configured | ForEach-Object { Write-Host "  - $($_.ObjectType)" }
+      register: dc_audit_sacl_verify_result
+      changed_when: false
+
+    - name: Display verification result
+      ansible.builtin.debug:
+        msg: "{{ dc_audit_sacl_verify_result.stdout_lines }}"

--- a/roles/sysmon/README.md
+++ b/roles/sysmon/README.md
@@ -1,0 +1,64 @@
+<!-- DOCSIBLE START -->
+# sysmon
+
+## Description
+
+Install and configure Sysinternals Sysmon on Windows hosts
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `sysmon_service_name` | str | <code>Sysmon64</code> | No description |
+| `sysmon_install_dir` | str | <code>C:\Windows</code> | No description |
+| `sysmon_binary_path` | str | <code>C:\Windows\Sysmon64.exe</code> | No description |
+| `sysmon_config_path` | str | <code>C:\ProgramData\Sysmon\sysmonconfig.xml</code> | No description |
+| `sysmon_windows_temp_dir` | str | <code>C:\Windows\Temp</code> | No description |
+| `sysmon_installer_url` | str | <code>https://download.sysinternals.com/files/Sysmon.zip</code> | No description |
+| `sysmon_config_url` | str | <code>https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml</code> | No description |
+| `sysmon_enforce_config` | bool | <code>True</code> | No description |
+
+## Tasks
+
+### main.yml
+
+
+- **Include OS-specific tasks** (ansible.builtin.include_tasks)
+
+### windows.yml
+
+
+- **Check if Sysmon service is already installed** (ansible.windows.win_service)
+- **Ensure Sysmon config directory exists** (ansible.windows.win_file)
+- **Fetch Sysmon config (SwiftOnSecurity)** (ansible.windows.win_get_url)
+- **Download Sysmon installer** (ansible.windows.win_get_url) - Conditional
+- **Extract Sysmon installer** (community.windows.win_unzip) - Conditional
+- **Install Sysmon with config** (ansible.windows.win_command) - Conditional
+- **Wait for Sysmon service to be running** (ansible.windows.win_service)
+- **Clean up installer files** (ansible.windows.win_file) - Conditional
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - sysmon
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: l50
+- **License**: MIT
+
+## Platforms
+
+
+- Windows: all
+<!-- DOCSIBLE END -->

--- a/roles/sysmon/defaults/main.yml
+++ b/roles/sysmon/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+sysmon_service_name: "Sysmon64"
+sysmon_install_dir: "C:\\Windows"
+sysmon_binary_path: "C:\\Windows\\Sysmon64.exe"
+sysmon_config_path: "C:\\ProgramData\\Sysmon\\sysmonconfig.xml"
+
+sysmon_windows_temp_dir: "C:\\Windows\\Temp"
+sysmon_installer_url: "https://download.sysinternals.com/files/Sysmon.zip"
+
+# SwiftOnSecurity sysmon-config — pinned to a specific commit for reproducibility.
+# Update the SHA to roll forward.
+sysmon_config_url: "https://raw.githubusercontent.com/SwiftOnSecurity/sysmon-config/master/sysmonconfig-export.xml"
+
+# When true, re-apply the config on every run (Sysmon64.exe -c <config>).
+# Cheap, idempotent, and ensures drift is corrected.
+sysmon_enforce_config: true

--- a/roles/sysmon/handlers/main.yml
+++ b/roles/sysmon/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Reload sysmon config
+  ansible.windows.win_command: '"{{ sysmon_binary_path }}" -c "{{ sysmon_config_path }}"'

--- a/roles/sysmon/meta/main.yml
+++ b/roles/sysmon/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: sysmon
+  namespace: l50
+  author: Jayson Grace
+  description: Install and configure Sysinternals Sysmon on Windows hosts
+  company: l50
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Windows
+      versions:
+        - all
+  galaxy_tags:
+    - sysmon
+    - sysinternals
+    - windows
+    - security
+    - telemetry
+    - detection
+
+dependencies: []

--- a/roles/sysmon/tasks/main.yml
+++ b/roles/sysmon/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Include OS-specific tasks
+  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"

--- a/roles/sysmon/tasks/windows.yml
+++ b/roles/sysmon/tasks/windows.yml
@@ -1,0 +1,64 @@
+---
+- name: Check if Sysmon service is already installed
+  ansible.windows.win_service:
+    name: "{{ sysmon_service_name }}"
+  register: sysmon_service_info
+  failed_when: false
+
+- name: Ensure Sysmon config directory exists
+  ansible.windows.win_file:
+    path: "C:\\ProgramData\\Sysmon"
+    state: directory
+
+- name: Fetch Sysmon config (SwiftOnSecurity)
+  ansible.windows.win_get_url:
+    url: "{{ sysmon_config_url }}"
+    dest: "{{ sysmon_config_path }}"
+    force: true
+  register: sysmon_config_download
+  notify: Reload sysmon config
+
+- name: Download Sysmon installer
+  ansible.windows.win_get_url:
+    url: "{{ sysmon_installer_url }}"
+    dest: "{{ sysmon_windows_temp_dir }}\\Sysmon.zip"
+  when: not sysmon_service_info.exists
+
+- name: Extract Sysmon installer
+  community.windows.win_unzip:
+    src: "{{ sysmon_windows_temp_dir }}\\Sysmon.zip"
+    dest: "{{ sysmon_windows_temp_dir }}\\Sysmon"
+  when: not sysmon_service_info.exists
+
+- name: Install Sysmon with config
+  ansible.windows.win_command: >-
+    "{{ sysmon_windows_temp_dir }}\Sysmon\Sysmon64.exe"
+    -accepteula -i "{{ sysmon_config_path }}"
+  when: not sysmon_service_info.exists
+  register: sysmon_install_result
+  changed_when: sysmon_install_result.rc == 0
+  # Sysmon returns 0 on install. The driver registration step occasionally
+  # exits non-zero on rerun if already present; let the next idempotent check
+  # catch real failures.
+  failed_when:
+    - sysmon_install_result.rc != 0
+    - "'is already installed' not in (sysmon_install_result.stdout | default(''))"
+
+- name: Wait for Sysmon service to be running
+  ansible.windows.win_service:
+    name: "{{ sysmon_service_name }}"
+    state: started
+    start_mode: auto
+  register: sysmon_service_state
+  until: sysmon_service_state.state == "running"
+  retries: 6
+  delay: 5
+
+- name: Clean up installer files
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ sysmon_windows_temp_dir }}\\Sysmon.zip"
+    - "{{ sysmon_windows_temp_dir }}\\Sysmon"
+  when: not sysmon_service_info.exists


### PR DESCRIPTION
**Key Changes:**

- New `aws_ssm_agent` role installs and configures AWS SSM Agent on Ubuntu/Debian and Windows hosts, enabling AWS Systems Manager capabilities (Session Manager, Run Command, Patch Manager)
- Handles both snap-managed and dpkg-managed SSM agent installations on Linux, skipping redundant installs gracefully
- Includes optional systemd OOM protection via a drop-in override that caps SSM agent memory and lowers its OOM score to protect worker processes
- README updated to reflect the new role in the collection diagram, roles table, and description section

**Added:**

- Cross-platform install logic - `tasks/linux.yml` detects snap vs. dpkg installation paths, downloads and installs the `.deb` package when not already present, enables and starts the systemd service, and cleans up temp files; `tasks/windows.yml` checks for an existing `AmazonSSMAgent` service, downloads and silently installs the `.exe` if absent, ensures the service is running, and removes the installer
- OOM protection - `templates/ssm-oom-protect.conf.j2` deploys a systemd drop-in setting `OOMScoreAdjust=-900` and a configurable `MemoryMax` cgroup cap (default `512M`) so the kernel targets SSM before other workloads under memory pressure
- Health-check templates - `check-ssm-agent.sh.j2` (Linux) and `check-ssm-agent.ps1.j2` (Windows) provide restart-on-failure scripts with timestamped logging
- Role scaffolding - `defaults/main.yml` exposes `aws_ssm_agent_oom_protect`, `aws_ssm_agent_memory_max`, `aws_ssm_agent_temp_dir`, and `aws_ssm_agent_aws_region`; `vars/main.yml` defines install URLs and Windows path constants; `handlers/main.yml` restarts the appropriate service on both platforms; `meta/main.yml` registers Galaxy metadata for Ubuntu, Debian, and Windows
- Role documentation - `roles/aws_ssm_agent/README.md` documents all variables, task summaries, example playbook, and platform support

**Changed:**

- Collection diagram and roles table in `README.md` updated to include `aws_ssm_agent` in alphabetical order alongside an expanded description of its purpose and OOM protection behavior