### PR TITLE
docs: update changelog and bump collection version to 1.1.0

### DIFF
--- a/changelogs/CHANGELOG.rst
+++ b/changelogs/CHANGELOG.rst
@@ -1,8 +1,38 @@
 ==============================================
-Bulwark Ansible Collection 1.0.1 Release Notes
+Bulwark Ansible Collection 1.1.0 Release Notes
 ==============================================
 
 .. contents:: Topics
+
+v1.1.0
+======
+
+Release Summary
+---------------
+
+Feature release introducing five new Ansible roles for cloud infrastructure management, Windows host instrumentation, and security monitoring, plus reliability and security improvements to the runzero_explorer role.
+
+Added
+-----
+
+- aws_cloudwatch_agent - New Ansible role for deploying and configuring AWS CloudWatch Agent across supported platforms (#524).
+- aws_cloudwatch_agent, aws_ssm_agent - Added Molecule test suites for integration testing (#529).
+- aws_ssm_agent - New Ansible role for cross-platform AWS Systems Manager Agent management (#525).
+- dc_audit_sacl - New Ansible role for configuring Domain Controller audit SACL policies to support attack detection (#523).
+- grafana_alloy - New Ansible role for Grafana Alloy deployment targeting Windows event log collection and forwarding (#526).
+- runzero_explorer - Added resilient download configuration with retry logic for improved reliability in network-constrained environments (#509).
+- sysmon - New Ansible role for Windows host instrumentation using Sysinternals Sysmon (#522).
+
+Changed
+-------
+
+- Updated Ansible collection dependencies (amazon.aws 11.4.0, ansible.windows 3.6.1, community.general 13.x) and ansible-core to 2.21.1.
+- Updated Python, Go, and Task tooling versions across CI workflows.
+
+Fixed
+-----
+
+- README - Fixed roles table markers so the pre-commit hook passes validation (#497).
 
 v1.0.1
 ======

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -53,3 +53,33 @@ releases:
       - Removed Ruby-based markdown linter (mdl) in favor of markdownlint-cli
       - Removed custom regex managers from Renovate configuration
     release_date: '2025-09-04'
+  1.1.0:
+    changes:
+      added:
+      - aws_cloudwatch_agent - New Ansible role for deploying and configuring AWS
+        CloudWatch Agent across supported platforms (#524).
+      - aws_cloudwatch_agent, aws_ssm_agent - Added Molecule test suites for integration
+        testing (#529).
+      - aws_ssm_agent - New Ansible role for cross-platform AWS Systems Manager Agent
+        management (#525).
+      - dc_audit_sacl - New Ansible role for configuring Domain Controller audit SACL
+        policies to support attack detection (#523).
+      - grafana_alloy - New Ansible role for Grafana Alloy deployment targeting Windows
+        event log collection and forwarding (#526).
+      - runzero_explorer - Added resilient download configuration with retry logic
+        for improved reliability in network-constrained environments (#509).
+      - sysmon - New Ansible role for Windows host instrumentation using Sysinternals
+        Sysmon (#522).
+      changed:
+      - Updated Ansible collection dependencies (amazon.aws 11.4.0, ansible.windows
+        3.6.1, community.general 13.x) and ansible-core to 2.21.1.
+      - Updated Python, Go, and Task tooling versions across CI workflows.
+      fixed:
+      - README - Fixed roles table markers so the pre-commit hook passes validation
+        (#497).
+      release_summary: Feature release introducing five new Ansible roles for cloud
+        infrastructure management, Windows host instrumentation, and security monitoring,
+        plus reliability and security improvements to the runzero_explorer role.
+    fragments:
+    - 1.1.0.yaml
+    release_date: '2026-07-09'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: l50
 name: bulwark
-version: "1.0.1"
+version: "1.1.0"
 readme: README.md
 authors:
   - Jayson Grace <techvomit.net>


### PR DESCRIPTION
**Key Changes:**

- Bumped Ansible collection version from 1.0.1 to 1.1.0 in `galaxy.yml`
- Added full v1.1.0 release notes documenting five new roles, dependency updates, and a README fix
- Populated `changelog.yaml` with structured v1.1.0 release entries including added, changed, and fixed sections

**Changed:**

- Collection version - Updated `galaxy.yml` version string from `1.0.1` to `1.1.0` to reflect the new feature release
- CHANGELOG.rst title and content - Updated document heading to reference v1.1.0 and prepended the new release block covering new roles (`aws_cloudwatch_agent`, `aws_ssm_agent`, `dc_audit_sacl`, `grafana_alloy`, `sysmon`), retry logic improvements to `runzero_explorer`, updated collection dependencies (`amazon.aws 11.4.0`, `ansible.windows 3.6.1`, `community.general 13.x`, `ansible-core 2.21.1`), and the README pre-commit fix
- Structured changelog data - Added the `1.1.0` release block to `changelog.yaml` with dated entry (`2026-07-09`), fragment reference, and categorized change entries mirroring the RST changelog content