### PR TITLE
feat: add powershell_logging role for attack detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ graph TD
     Roles --> R1[aws_cloudwatch_agent 🧪]
     Roles --> R2[aws_ssm_agent 🧪]
     Roles --> R3[dc_audit_sacl]
-    Roles --> R4[runzero_explorer 🧪]
-    Roles --> R5[sysmon]
+    Roles --> R4[powershell_logging]
+    Roles --> R5[runzero_explorer 🧪]
+    Roles --> R6[sysmon]
     Collection --> Playbooks[📚 Playbooks]
     Playbooks --> PB0[runzero_explorer 🧪]
 ```
@@ -55,6 +56,7 @@ ansible-galaxy collection build --force && \
 | [`aws_cloudwatch_agent`](roles/aws_cloudwatch_agent/README.md) | Install and configure AWS CloudWatch Agent |
 | [`aws_ssm_agent`](roles/aws_ssm_agent/README.md) | Install and configure AWS SSM Agent |
 | [`dc_audit_sacl`](roles/dc_audit_sacl/README.md) | Configure SACL auditing on Domain Controllers for attack detection |
+| [`powershell_logging`](roles/powershell_logging/README.md) | Enable PowerShell script block and module logging for attack detection |
 | [`runzero_explorer`](roles/runzero_explorer/README.md) | Install the runZero explorer |
 | [`sysmon`](roles/sysmon/README.md) | Install and configure Sysinternals Sysmon on Windows hosts |
 

--- a/changelogs/fragments/powershell-logging.yaml
+++ b/changelogs/fragments/powershell-logging.yaml
@@ -1,0 +1,8 @@
+---
+added:
+  - Added role `powershell_logging` to enable PowerShell script block logging
+    (event 4104) and module logging (event 4103) via machine policy, and to
+    raise the Microsoft-Windows-PowerShell/Operational channel size so those
+    events survive long enough to be shipped. Subscribing a log shipper to
+    that channel without these policy settings yields only engine lifecycle
+    events, never the script content needed for detection.

--- a/roles/powershell_logging/README.md
+++ b/roles/powershell_logging/README.md
@@ -1,0 +1,68 @@
+<!-- DOCSIBLE START -->
+# powershell_logging
+
+## Description
+
+Enable PowerShell script block and module logging for attack detection
+
+## Requirements
+
+- Ansible >= 2.14
+
+## Role Variables
+
+### Default Variables (main.yml)
+
+| Variable | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| `powershell_logging_enable_script_block` | bool | <code>True</code> | No description |
+| `powershell_logging_enable_script_block_invocation` | bool | <code>False</code> | No description |
+| `powershell_logging_enable_module_logging` | bool | <code>True</code> | No description |
+| `powershell_logging_module_names` | list | <code>&#91;&#93;</code> | No description |
+| `powershell_logging_module_names.0` | str | <code>*</code> | No description |
+| `powershell_logging_enable_transcription` | bool | <code>False</code> | No description |
+| `powershell_logging_transcript_output_directory` | str | <code>C:\ProgramData\PSTranscripts</code> | No description |
+| `powershell_logging_transcription_invocation_header` | bool | <code>True</code> | No description |
+| `powershell_logging_operational_max_size_mb` | int | <code>256</code> | No description |
+| `powershell_logging_policy_key` | str | <code>HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell</code> | No description |
+| `powershell_logging_operational_channel` | str | <code>Microsoft-Windows-PowerShell/Operational</code> | No description |
+
+## Tasks
+
+### main.yml
+
+
+- **Configure script block logging (event 4104)** (ansible.windows.win_regedit)
+- **Configure script block invocation logging (events 4105/4106)** (ansible.windows.win_regedit)
+- **Configure module logging (event 4103)** (ansible.windows.win_regedit)
+- **Register modules for pipeline logging** (ansible.windows.win_regedit) - Conditional
+- **Configure transcription** (block) - Conditional
+- **Ensure transcript output directory exists** (ansible.windows.win_file)
+- **Enable transcription** (ansible.windows.win_regedit)
+- **Set transcript output directory** (ansible.windows.win_regedit)
+- **Configure transcript invocation header** (ansible.windows.win_regedit)
+- **Size the PowerShell Operational channel** (block) - Conditional
+- **Read current Operational channel size** (ansible.windows.win_shell)
+- **Set Operational channel size** (ansible.windows.win_shell) - Conditional
+- **Verify PowerShell logging policy** (ansible.windows.win_shell)
+- **Display verification result** (ansible.builtin.debug)
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  roles:
+    - powershell_logging
+```
+
+## Author Information
+
+- **Author**: Jayson Grace
+- **Company**: l50
+- **License**: MIT
+
+## Platforms
+
+
+- Windows: 2019, 2022
+<!-- DOCSIBLE END -->

--- a/roles/powershell_logging/defaults/main.yml
+++ b/roles/powershell_logging/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+# PowerShell Logging Configuration
+# Turns on the policy settings that make Microsoft-Windows-PowerShell/Operational
+# useful to a detection pipeline. Subscribing to that channel without these
+# settings yields only engine lifecycle events (40961/40962), never script bodies.
+
+# Script block logging (event 4104) records the deobfuscated script text as it
+# is compiled. This is the single setting that makes PowerShell telemetry worth
+# collecting; leave it on unless you have a specific reason not to.
+powershell_logging_enable_script_block: true
+
+# Invocation logging (events 4105/4106) adds a start and stop record for every
+# script block executed. Extremely high volume. Only enable when you need
+# execution timing rather than content.
+powershell_logging_enable_script_block_invocation: false
+
+# Module/pipeline logging (event 4103) records pipeline execution details for
+# the modules named below. "*" covers every module.
+powershell_logging_enable_module_logging: true
+powershell_logging_module_names:
+  - "*"
+
+# Transcription writes full session transcripts to disk instead of the event
+# log, so it needs a separate collection path. Off by default.
+powershell_logging_enable_transcription: false
+powershell_logging_transcript_output_directory: 'C:\ProgramData\PSTranscripts'
+powershell_logging_transcription_invocation_header: true
+
+# The Operational channel defaults to 15 MB. With script block logging enabled
+# a noisy host can wrap that in minutes and lose events between shipper polls.
+# Set to 0 to leave the channel size alone.
+powershell_logging_operational_max_size_mb: 256
+
+# Policy hive the settings are written to. Values here take precedence over
+# per-user settings and match what Group Policy would apply.
+powershell_logging_policy_key: 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell'
+powershell_logging_operational_channel: "Microsoft-Windows-PowerShell/Operational"

--- a/roles/powershell_logging/meta/main.yml
+++ b/roles/powershell_logging/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: powershell_logging
+  namespace: l50
+  author: Jayson Grace
+  description: Enable PowerShell script block and module logging for attack detection
+  company: l50
+  license: MIT
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+  galaxy_tags:
+    - windows
+    - security
+    - logging
+    - auditing
+    - powershell
+
+dependencies: []

--- a/roles/powershell_logging/tasks/main.yml
+++ b/roles/powershell_logging/tasks/main.yml
@@ -1,0 +1,109 @@
+---
+# PowerShell Logging Configuration
+# Writes the policy values that populate Microsoft-Windows-PowerShell/Operational
+# with script content (4104) and pipeline detail (4103).
+
+- name: Configure script block logging (event 4104)
+  ansible.windows.win_regedit:
+    path: '{{ powershell_logging_policy_key }}\ScriptBlockLogging'
+    name: EnableScriptBlockLogging
+    data: "{{ 1 if powershell_logging_enable_script_block else 0 }}"
+    type: dword
+    state: present
+
+- name: Configure script block invocation logging (events 4105/4106)
+  ansible.windows.win_regedit:
+    path: '{{ powershell_logging_policy_key }}\ScriptBlockLogging'
+    name: EnableScriptBlockInvocationLogging
+    data: "{{ 1 if powershell_logging_enable_script_block_invocation else 0 }}"
+    type: dword
+    state: present
+
+- name: Configure module logging (event 4103)
+  ansible.windows.win_regedit:
+    path: '{{ powershell_logging_policy_key }}\ModuleLogging'
+    name: EnableModuleLogging
+    data: "{{ 1 if powershell_logging_enable_module_logging else 0 }}"
+    type: dword
+    state: present
+
+# EnableModuleLogging alone logs nothing; the ModuleNames subkey decides which
+# modules are in scope, as name and data pairs of the same string.
+- name: Register modules for pipeline logging
+  ansible.windows.win_regedit:
+    path: '{{ powershell_logging_policy_key }}\ModuleLogging\ModuleNames'
+    name: "{{ item }}"
+    data: "{{ item }}"
+    type: string
+    state: present
+  loop: "{{ powershell_logging_module_names }}"
+  when: powershell_logging_enable_module_logging | bool
+
+- name: Configure transcription
+  when: powershell_logging_enable_transcription | bool
+  block:
+    - name: Ensure transcript output directory exists
+      ansible.windows.win_file:
+        path: "{{ powershell_logging_transcript_output_directory }}"
+        state: directory
+
+    - name: Enable transcription
+      ansible.windows.win_regedit:
+        path: '{{ powershell_logging_policy_key }}\Transcription'
+        name: EnableTranscripting
+        data: 1
+        type: dword
+        state: present
+
+    - name: Set transcript output directory
+      ansible.windows.win_regedit:
+        path: '{{ powershell_logging_policy_key }}\Transcription'
+        name: OutputDirectory
+        data: "{{ powershell_logging_transcript_output_directory }}"
+        type: string
+        state: present
+
+    - name: Configure transcript invocation header
+      ansible.windows.win_regedit:
+        path: '{{ powershell_logging_policy_key }}\Transcription'
+        name: EnableInvocationHeader
+        data: "{{ 1 if powershell_logging_transcription_invocation_header else 0 }}"
+        type: dword
+        state: present
+
+- name: Size the PowerShell Operational channel
+  when: powershell_logging_operational_max_size_mb | int > 0
+  block:
+    - name: Read current Operational channel size
+      ansible.windows.win_shell: |
+        $log = wevtutil gl "{{ powershell_logging_operational_channel }}"
+        $match = $log | Select-String -Pattern '^\s*maxSize:\s*(\d+)'
+        if ($match) { $match.Matches[0].Groups[1].Value } else { "" }
+      register: powershell_logging_channel_size
+      changed_when: false
+
+    - name: Set Operational channel size
+      ansible.windows.win_shell: >-
+        wevtutil sl "{{ powershell_logging_operational_channel }}"
+        /ms:{{ powershell_logging_operational_max_size_mb | int * 1048576 }}
+      when: >-
+        (powershell_logging_channel_size.stdout | trim | int)
+        != (powershell_logging_operational_max_size_mb | int * 1048576)
+      changed_when: true
+
+- name: Verify PowerShell logging policy
+  ansible.windows.win_shell: |
+    $key = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\PowerShell"
+    $sbl = (Get-ItemProperty "$key\ScriptBlockLogging" -ErrorAction SilentlyContinue).EnableScriptBlockLogging
+    $mod = (Get-ItemProperty "$key\ModuleLogging" -ErrorAction SilentlyContinue).EnableModuleLogging
+    $size = (wevtutil gl "{{ powershell_logging_operational_channel }}" |
+      Select-String -Pattern '^\s*maxSize:\s*(\d+)').Matches[0].Groups[1].Value
+    Write-Host "EnableScriptBlockLogging (4104): $(if ($sbl -eq 1) { 'enabled' } else { 'DISABLED' })"
+    Write-Host "EnableModuleLogging (4103):      $(if ($mod -eq 1) { 'enabled' } else { 'DISABLED' })"
+    Write-Host "Operational channel maxSize:     $([math]::Round($size / 1MB)) MB"
+  register: powershell_logging_verify
+  changed_when: false
+
+- name: Display verification result
+  ansible.builtin.debug:
+    msg: "{{ powershell_logging_verify.stdout_lines }}"


### PR DESCRIPTION
**Key Changes:**

- Introduced a new `powershell_logging` Ansible role that enables PowerShell script block logging (event 4104) and module logging (event 4103) via machine policy
- Sizes the Microsoft-Windows-PowerShell/Operational channel so script content survives long enough to be shipped to a detection pipeline
- Documented the role in the collection README and added a changelog fragment

**Added:**

- PowerShell logging role tasks - Implemented `roles/powershell_logging/tasks/main.yml` to write policy registry values for script block logging, script block invocation logging (4105/4106), and module logging, register modules for pipeline logging, optionally configure transcription, resize the Operational channel via `wevtutil`, and verify the applied policy
- Role default variables - Added `roles/powershell_logging/defaults/main.yml` with documented toggles for each logging feature, module name scope (`*` by default), transcription output path, a 256 MB Operational channel size (0 to skip), and the policy hive path; comments explain why each setting matters for detection
- Role metadata - Added `roles/powershell_logging/meta/main.yml` declaring Galaxy info, MIT license, minimum Ansible 2.14, Windows 2019/2022 platforms, and security/logging tags
- Role documentation - Added `roles/powershell_logging/README.md` describing variables, tasks, requirements, and an example playbook
- Changelog fragment - Added `changelogs/fragments/powershell-logging.yaml` documenting the new role and the rationale for raising the channel size

**Changed:**

- Collection documentation - Updated `README.md` to include `powershell_logging` in the roles graph and the roles reference table