### PR TITLE
fix: default alloy_instance_id to ec2 instance id fact

### DIFF
--- a/changelogs/fragments/alloy-instance-id.yaml
+++ b/changelogs/fragments/alloy-instance-id.yaml
@@ -1,0 +1,10 @@
+---
+fixed:
+  - Default `alloy_instance_id` to the `ansible_ec2_instance_id` fact instead of
+    an empty string, so Alloy stream labels carry a real instance ID when the
+    caller has gathered EC2 metadata. Previously every stream shipped
+    `instance_id=""` unless the ID was passed explicitly, and a selector such as
+    `{instance_id="i-0123456789abcdef0"}` returned no results — which reads as
+    "this host is quiet" rather than "this selector matched nothing." Callers
+    that set the variable explicitly are unaffected, since role defaults are the
+    lowest-precedence source.

--- a/roles/alloy/README.md
+++ b/roles/alloy/README.md
@@ -19,7 +19,7 @@ Install and configure Grafana Alloy for Windows hosts
 | `alloy_env` | str | <code>dev</code> | No description |
 | `alloy_deployment_name` | str | <code></code> | No description |
 | `alloy_server_id` | str | <code></code> | No description |
-| `alloy_instance_id` | str | <code></code> | No description |
+| `alloy_instance_id` | str | <code>{{ ansible_ec2_instance_id &#124; default('') }}</code> | No description |
 | `alloy_loki_endpoint` | str | <code></code> | No description |
 | `alloy_otlp_vector_endpoint` | str | <code></code> | No description |
 | `alloy_otlp_loki_endpoint` | str | <code></code> | No description |

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -6,7 +6,7 @@ alloy_version: "1.17.1"
 alloy_env: "dev"
 alloy_deployment_name: ""
 alloy_server_id: ""
-alloy_instance_id: ""
+alloy_instance_id: "{{ ansible_ec2_instance_id | default('') }}"
 alloy_loki_endpoint: ""
 
 # OTLP HTTP endpoints for the log-forwarding pipeline. The role sends parsed


### PR DESCRIPTION
**Key Changes:**

- Changed the `alloy_instance_id` role default to fall back to the `ansible_ec2_instance_id` fact instead of an empty string, so Alloy stream labels carry a real instance ID by default
- Preserved caller overrides since role defaults are the lowest-precedence source
- Documented the fix in a changelog fragment explaining the previous "silent selector" behavior

**Added:**

- Changelog fragment describing the fix and its motivation, including how empty `instance_id` labels caused selectors like `{instance_id="i-0123456789abcdef0"}` to return no results — reading as "this host is quiet" rather than "this selector matched nothing" - `changelogs/fragments/alloy-instance-id.yaml`

**Changed:**

- Default value of `alloy_instance_id` now resolves to `{{ ansible_ec2_instance_id | default('') }}`, ensuring gathered EC2 metadata populates Alloy stream labels automatically - `roles/alloy/defaults/main.yml`
- Updated the role documentation to reflect the new default value for `alloy_instance_id` - `roles/alloy/README.md`